### PR TITLE
Load and test from host, not vagrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,22 +137,6 @@ SDK_SOURCE_PATH  += lib_blewbxx lib_blewbxx_impl
 SDK_SOURCE_PATH  += lib_ux
 endif
 
-load: all
-	python -m ledgerblue.loadApp $(APP_LOAD_PARAMS)
-
-load-offline: all
-	python -m ledgerblue.loadApp $(APP_LOAD_PARAMS) --offline
-
-delete:
-	python -m ledgerblue.deleteApp $(COMMON_DELETE_PARAMS)
-
-release: all
-	export APP_LOAD_PARAMS_EVALUATED="$(shell printf '\\"%s\\" ' $(APP_LOAD_PARAMS))"; \
-	cat load-template.sh | envsubst > load.sh
-	chmod +x load.sh
-	tar -zcf solana-ledger-app-$(APPVERSION).tar.gz load.sh bin/app.hex
-	rm load.sh
-
 # import generic rules from the sdk
 include $(BOLOS_SDK)/Makefile.rules
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ source prepare-devenv.sh x
 
 ## Building and installing
 
-Compile and load the app onto the device:
+Compile:
 
 ```bash
-make load
+make
 ```
 
 Refresh the repo (required after Makefile edits):
@@ -58,10 +58,18 @@ Refresh the repo (required after Makefile edits):
 make clean
 ```
 
-Remove the app from the device:
+To load the app onto the device, from the *host* machine:
+
 ```bash
-make delete
+make -f host.mk
 ```
+
+Remove the app from the device:
+
+```bash
+make -f host.mk delete
+```
+
 
 ## Example of Ledger wallet functionality
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,14 +51,6 @@ Vagrant.configure("2") do |config|
   # Example for VirtualBox:
   #
   config.vm.provider "virtualbox" do |vb|
-      # Enable USB
-      vb.customize ["modifyvm", :id, "--usb", "on"]
-      vb.customize ["usbfilter", "add", "0",
-          "--target", :id,
-          "--name", "Ledger Nano S",
-          "--manufacturer", "Ledger",
-          "--product", "Nano S"]
-
   #   # Display the VirtualBox GUI when booting the machine
   #   vb.gui = true
   #
@@ -74,17 +66,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    apt-get install -y gcc-multilib g++-multilib python3-pip python-pip
-
-    wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
-    sed -e 's/$/, OWNER="vagrant"/' -i /etc/udev/rules.d/20-hw1.rules
-    udevadm trigger
-    udevadm control --reload-rules
-
-    apt-get install -y libudev-dev libusb-1.0-0-dev pkg-config
-    python3 -m pip install ledgerblue
-    pip install ledgerblue
-    python3 -m pip install base58==1.0.3
+    apt-get install -y gcc-multilib g++-multilib python3-pip
 
     BASHRC=/home/vagrant/.bashrc
     grep -qF -- BOLOS_ENV $BASHRC || echo "export BOLOS_ENV=/bolos-env" >> $BASHRC
@@ -99,10 +81,9 @@ Vagrant.configure("2") do |config|
         tar xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz -C /bolos-env
         mv /bolos-env/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 /bolos-env/clang-arm-fropi
     fi
-  SHELL
 
-  config.vm.provision "shell", privileged: false, inline: <<-SHELL
-    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    apt-get install -y libudev-dev libusb-1.0-0-dev pkg-config
+    python3 -m pip install ledgerblue
   SHELL
 
   # cd to /vagrant when "vagrant ssh"

--- a/host.mk
+++ b/host.mk
@@ -1,0 +1,25 @@
+BOLOS_SDK = nanos-secure-sdk
+include $(BOLOS_SDK)/Makefile.defines
+
+APP_LOAD_PARAMS= --curve ed25519 --path "44'/501'" --appFlags 0x240 $(COMMON_LOAD_PARAMS)
+
+all: load
+
+load:
+	python3 -m ledgerblue.loadApp $(APP_LOAD_PARAMS)
+
+load-offline:
+	python3 -m ledgerblue.loadApp $(APP_LOAD_PARAMS) --offline
+
+delete:
+	python3 -m ledgerblue.deleteApp $(COMMON_DELETE_PARAMS)
+
+release:
+	export APP_LOAD_PARAMS_EVALUATED="$(shell printf '\\"%s\\" ' $(APP_LOAD_PARAMS))"; \
+	cat load-template.sh | envsubst > load.sh
+	chmod +x load.sh
+	tar -zcf solana-ledger-app-$(APPVERSION).tar.gz load.sh bin/app.hex
+	rm load.sh
+
+deps:
+	python3 -mpip install ledgerblue


### PR DESCRIPTION
#### Problem

Working with Vagrant can be a pain. For instance, the Ledger needs to be unlocked when `vagrant up`. Otherwise the device isn't detected and won't be able to connect.  Also, virtualbox hijacks those USB devices, such that the host machine can't access them. The workaround is to `vagrant suspend` to switch to the host and then `vagrant resume` to go back in.  It's a long edit-compile-load-test cycle.

#### Proposed changes

Abandon vagrant/virtualbox for everything except the device build.  New workflow:

1. Open two shells, one for the app build, one for coding/unit-testing/loading/device-testing.
2. On the host, use `make` from `libsol` to run the unit-tests
3. Via `vagrant ssh`, use `make` to run the app build.
4. On the host, use new `make -f host.mk load` to load the device
5 On the host, use `cargo test` from `rust-tests` for device testing
