### PR TITLE
Add support for long messages

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -7,8 +7,9 @@
 
 #define P1_CONFIRM 0x01
 #define P1_NON_CONFIRM 0x00
-#define P1_FIRST 0x00
-#define P1_MORE 0x80
+
+#define P2_EXTEND 0x01
+#define P2_MORE 0x02
 
 #define MAX_MESSAGE_LENGTH 1500  // MTU Size
 #define SIGNATURE_LENGTH 64

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -8,7 +8,6 @@
 #include "system_instruction.h"
 
 static char messageHash[BASE58_HASH_LENGTH];
-static uint8_t signature[SIGNATURE_LENGTH];
 static char feePayer[BASE58_PUBKEY_LENGTH];
 static char senderPubkey[BASE58_PUBKEY_LENGTH];
 static char recipientPubkey[BASE58_PUBKEY_LENGTH];
@@ -17,6 +16,11 @@ static char recipientPubkey[BASE58_PUBKEY_LENGTH];
 static char messageTransfer[MESSAGE_TRANSFER_SIZE];
 
 #define SUMMARY_LENGTH 7
+
+static uint8_t G_message[MAX_MESSAGE_LENGTH];
+static int G_messageLength;
+static uint32_t G_derivationPath[BIP32_PATH];
+static int G_derivationPathLength;
 
 void derive_private_key(cx_ecfp_private_key_t *privateKey, uint32_t *derivationPath, uint8_t derivationPathLength) {
     uint8_t privateKeyData[32];
@@ -27,6 +31,10 @@ void derive_private_key(cx_ecfp_private_key_t *privateKey, uint32_t *derivationP
 
 static uint8_t set_result_sign_message() {
     uint8_t tx = 64;
+    uint8_t signature[SIGNATURE_LENGTH];
+    cx_ecfp_private_key_t privateKey;
+    derive_private_key(&privateKey, G_derivationPath, G_derivationPathLength);
+    cx_eddsa_sign(&privateKey, CX_LAST, CX_SHA512, G_message, G_messageLength, NULL, 0, signature, SIGNATURE_LENGTH, NULL);
     os_memmove(G_io_apdu_buffer, signature, 64);
     return tx;
 }
@@ -102,22 +110,26 @@ UX_FLOW(ux_transfer_message,
 );
 
 void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, volatile unsigned int *tx) {
-    UNUSED(p2);
-    uint32_t derivationPath[BIP32_PATH];
-    uint8_t messageHashBytes[HASH_LENGTH];
+    if ((p2 & P2_EXTEND) == 0) {
+        MEMCLEAR(G_derivationPath);
+        MEMCLEAR(G_message);
+	G_messageLength = 0;
 
-    int derivationPathLength = read_derivation_path(dataBuffer, dataLength, derivationPath);
-    dataBuffer += 1 + derivationPathLength * 4;
-    dataLength -= 1 + derivationPathLength * 4;
-
-    cx_ecfp_private_key_t privateKey;
-    derive_private_key(&privateKey, derivationPath, derivationPathLength);
+        G_derivationPathLength = read_derivation_path(dataBuffer, dataLength, G_derivationPath);
+        dataBuffer += 1 + G_derivationPathLength * 4;
+        dataLength -= 1 + G_derivationPathLength * 4;
+    }
 
     int messageLength = U2BE(dataBuffer, 0);
     dataBuffer += 2;
-    uint8_t *message = dataBuffer;
+    os_memmove(G_message + G_messageLength, dataBuffer, messageLength);
+    G_messageLength += messageLength;
 
-    Parser parser = {message, messageLength};
+    if (p2 & P2_MORE) {
+        THROW(0x9000);
+    }
+
+    Parser parser = {G_message, G_messageLength};
     MessageHeader header;
     if (parse_message_header(&parser, &header)) {
         // This is not a valid Solana message
@@ -128,6 +140,7 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     SystemTransferInfo info;
     int system_transfer_err = parse_system_transfer_instructions(&parser, &header, &info);
 
+    uint8_t messageHashBytes[HASH_LENGTH];
     cx_hash_sha256(dataBuffer, dataLength, messageHashBytes, HASH_LENGTH);
 
     int len = encodeBase58(messageHashBytes, HASH_LENGTH, (uint8_t*) messageHash, BASE58_HASH_LENGTH);
@@ -137,8 +150,6 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     len = encodeBase58((uint8_t*) &header.pubkeys[0], PUBKEY_LENGTH, (uint8_t*) pubkeyBuffer, BASE58_PUBKEY_LENGTH);
     pubkeyBuffer[len] = '\0';
     print_summary(pubkeyBuffer, feePayer, SUMMARY_LENGTH, SUMMARY_LENGTH);
-
-    cx_eddsa_sign(&privateKey, CX_LAST, CX_SHA512, message, messageLength, NULL, 0, signature, SIGNATURE_LENGTH, NULL);
 
     if (p1 == P1_NON_CONFIRM) {
         // Uncomment this to allow blind signing.

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -122,6 +122,10 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 
     int messageLength = U2BE(dataBuffer, 0);
     dataBuffer += 2;
+
+    if (G_messageLength + messageLength > MAX_MESSAGE_LENGTH) {
+        THROW(EXCEPTION_OVERFLOW);
+    }
     os_memmove(G_message + G_messageLength, dataBuffer, messageLength);
     G_messageLength += messageLength;
 

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -722,23 +722,14 @@ dependencies = [
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-remote-wallet 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
- "solana-sdk 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
+ "solana-remote-wallet 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
+ "solana-sdk 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
 ]
 
 [[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lock_api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lock_api"
@@ -901,23 +892,6 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "owning_ref"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,15 +902,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.4.0"
+name = "parking_lot"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -950,6 +921,19 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1282,11 +1266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1410,8 +1389,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "solana-crate-features"
-version = "0.24.0"
-source = "git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13#b358ff66e12533bbef95f0b5e0cbb32fa03f6e13"
+version = "1.0.0"
+source = "git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e#dc02f2ea8b310643bdfd2095572a398a4f9d728e"
 dependencies = [
  "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1434,8 +1413,8 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "0.24.0"
-source = "git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13#b358ff66e12533bbef95f0b5e0cbb32fa03f6e13"
+version = "1.0.0"
+source = "git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e#dc02f2ea8b310643bdfd2095572a398a4f9d728e"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1444,23 +1423,23 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "0.24.0"
-source = "git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13#b358ff66e12533bbef95f0b5e0cbb32fa03f6e13"
+version = "1.0.0"
+source = "git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e#dc02f2ea8b310643bdfd2095572a398a4f9d728e"
 dependencies = [
  "base32 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hidapi 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
+ "solana-sdk 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-sdk"
-version = "0.24.0"
-source = "git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13#b358ff66e12533bbef95f0b5e0cbb32fa03f6e13"
+version = "1.0.0"
+source = "git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e#dc02f2ea8b310643bdfd2095572a398a4f9d728e"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1484,16 +1463,16 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-crate-features 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
- "solana-logger 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
- "solana-sdk-macro 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)",
+ "solana-crate-features 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
+ "solana-logger 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
+ "solana-sdk-macro 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "0.24.0"
-source = "git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13#b358ff66e12533bbef95f0b5e0cbb32fa03f6e13"
+version = "1.0.0"
+source = "git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e#dc02f2ea8b310643bdfd2095572a398a4f9d728e"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,11 +1488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "spin"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2182,7 +2156,6 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -2202,11 +2175,10 @@ dependencies = [
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum parking_lot_core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -2243,7 +2215,6 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -2259,14 +2230,13 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-"checksum solana-crate-features 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)" = "<none>"
-"checksum solana-logger 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)" = "<none>"
-"checksum solana-remote-wallet 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)" = "<none>"
-"checksum solana-sdk 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)" = "<none>"
-"checksum solana-sdk-macro 0.24.0 (git+https://github.com/solana-labs/solana?rev=b358ff66e12533bbef95f0b5e0cbb32fa03f6e13)" = "<none>"
+"checksum solana-crate-features 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)" = "<none>"
+"checksum solana-logger 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)" = "<none>"
+"checksum solana-remote-wallet 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)" = "<none>"
+"checksum solana-sdk 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)" = "<none>"
+"checksum solana-sdk-macro 1.0.0 (git+https://github.com/solana-labs/solana?rev=dc02f2ea8b310643bdfd2095572a398a4f9d728e)" = "<none>"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,5 +16,5 @@ serial_test = "0.3.2"
 serial_test_derive = "0.3.1"
 #solana-remote-wallet = { path = "../../solana/remote-wallet" }
 #solana-sdk = { path = "../../solana/sdk" }
-solana-remote-wallet = { git = "https://github.com/solana-labs/solana", rev = "b358ff66e12533bbef95f0b5e0cbb32fa03f6e13" }
-solana-sdk = { git = "https://github.com/solana-labs/solana", rev = "b358ff66e12533bbef95f0b5e0cbb32fa03f6e13" }
+solana-remote-wallet = { git = "https://github.com/solana-labs/solana", rev = "dc02f2ea8b310643bdfd2095572a398a4f9d728e" }
+solana-sdk = { git = "https://github.com/solana-labs/solana", rev = "dc02f2ea8b310643bdfd2095572a398a4f9d728e" }


### PR DESCRIPTION
#### Problem

Messages are limited to ~300 bytes

#### Proposed changes

* Set P2_MORE if this is we should wait for more messages before processing
* Set P2_EXTEND if the payload extends the message

Backward compatible, assuming client was always setting p2 to zero.

Fixes #23 

TODO:
- [x] Add an integration test
- [x] Update to a version of solana-remote-wallet that includes https://github.com/solana-labs/solana/pull/8394

cc: @CriesofCarrots