### PR TITLE
Throw invalid-data code when data-to-sign is not a solana message

### DIFF
--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -123,7 +123,7 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     MessageHeader header;
     if (parse_message_header(&parser, &header)) {
         // This is not a valid Solana message
-        sendResponse(0, false);
+        THROW(0x6a80);
         return;
     }
 


### PR DESCRIPTION
Currently, signMessage returns the same code if data cannot be parsed as a Solana message as it does when a user actively rejects to sign. Let's use the invalid-data code that we use in getPubkey instead.