### PR TITLE
Cleanup install script

### DIFF
--- a/host.mk
+++ b/host.mk
@@ -20,10 +20,10 @@ delete:
 
 release:
 	@echo "#!/usr/bin/env bash" > install.sh
-	@echo "mkdir -p bin && cat <<EOF >> bin/app.hex" >> install.sh
+	@echo "cat <<EOF >> app.hex" >> install.sh
 	@cat bin/app.hex >> install.sh
 	@echo "EOF" >> install.sh
-	export APP_LOAD_PARAMS_EVALUATED="$(shell printf '\\"%s\\" ' $(APP_LOAD_PARAMS))"; \
+	export APP_LOAD_PARAMS_EVALUATED="$(shell printf '\\"%s\\" ' $(APP_LOAD_PARAMS:bin/%=%))"; \
 	cat install-template.sh | envsubst >> install.sh
 	chmod +x install.sh
 

--- a/install-template.sh
+++ b/install-template.sh
@@ -1,4 +1,4 @@
 python3 -m venv ledger-env
 ledger-env/bin/pip3 install ledgerblue
 ledger-env/bin/python3 -m ledgerblue.loadApp $APP_LOAD_PARAMS_EVALUATED
-rm -rf ledger-env
+rm -rf ledger-env app.hex


### PR DESCRIPTION
#### Problem

Install script leaves behind `bin/app.hex`. Can't delete a `bin` directory, because that might be somebody's real `bin` directory.

#### Proposed changes

Generate just `app.hex` instead, so that we can safely delete it.