### PR TITLE
Consolidate instruction kind parsing

### DIFF
--- a/libsol/message.c
+++ b/libsol/message.c
@@ -16,15 +16,15 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
 
     const Pubkey* program_id = &header->pubkeys[instruction.program_id_index];
     if (memcmp(program_id, &system_program_id, PUBKEY_SIZE) == 0) {
-        SystemTransferInfo transfer_info;
-        if (parse_system_transfer_instructions(&parser, &instruction, header, &transfer_info) == 0) {
-            return print_system_transfer_info(&transfer_info, header, fields, fields_used);
+        SystemInfo info;
+        if (parse_system_instructions(&instruction, header, &info) == 0) {
+            return print_system_info(&info, header, fields, fields_used);
         }
     }
     else if (memcmp(program_id, &stake_program_id, PUBKEY_SIZE) == 0) {
-        DelegateStakeInfo delegate_info;
-        if (parse_delegate_stake_instructions(&parser, &instruction, header, &delegate_info) == 0) {
-            return print_delegate_stake_info(&delegate_info, header, fields, fields_used);
+        StakeInfo info;
+        if (parse_stake_instructions(&instruction, header, &info) == 0) {
+            return print_stake_info(&info, header, fields, fields_used);
         }
     }
 

--- a/libsol/stake_instruction.h
+++ b/libsol/stake_instruction.h
@@ -20,5 +20,12 @@ typedef struct DelegateStakeInfo {
     Pubkey* authorized_pubkey;
 } DelegateStakeInfo;
 
-int parse_delegate_stake_instructions(Parser* parser, Instruction* instruction, MessageHeader* header, DelegateStakeInfo* info);
-int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
+typedef struct StakeInfo {
+    enum StakeInstructionKind kind;
+    union {
+        DelegateStakeInfo delegate_stake;
+    };
+} StakeInfo;
+
+int parse_stake_instructions(Instruction* instruction, MessageHeader* header, StakeInfo* info);
+int print_stake_info(StakeInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);

--- a/libsol/stake_instruction_test.c
+++ b/libsol/stake_instruction_test.c
@@ -11,8 +11,8 @@ void test_parse_delegate_stake_instructions() {
     Instruction instruction;
     assert(parse_instruction(&parser, &instruction) == 0);
 
-    DelegateStakeInfo info;
-    assert(parse_delegate_stake_instructions(&parser, &instruction, &header, &info) == 0);
+    StakeInfo info;
+    assert(parse_stake_instructions(&instruction, &header, &info) == 0);
     assert(parser.buffer_length == 0);
 }
 

--- a/libsol/system_instruction.h
+++ b/libsol/system_instruction.h
@@ -24,6 +24,12 @@ typedef struct SystemTransferInfo {
     uint64_t lamports;
 } SystemTransferInfo;
 
-int parse_system_transfer_instructions(Parser* parser, Instruction* instruction, MessageHeader* header, SystemTransferInfo* info);
+typedef struct SystemInfo {
+    enum SystemInstructionKind kind;
+    union {
+        SystemTransferInfo transfer;
+    };
+} SystemInfo;
 
-int print_system_transfer_info(SystemTransferInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
+int parse_system_instructions(Instruction* instruction, MessageHeader* header, SystemInfo* info);
+int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);

--- a/libsol/system_instruction_test.c
+++ b/libsol/system_instruction_test.c
@@ -14,11 +14,11 @@ void test_parse_system_transfer_instructions() {
     assert(parse_instruction(&parser, &instruction) == 0);
 
     Pubkey* fee_payer_pubkey = &header.pubkeys[0];
-    SystemTransferInfo info;
-    assert(parse_system_transfer_instructions(&parser, &instruction, &header, &info) == 0);
+    SystemInfo info;
+    assert(parse_system_instructions(&instruction, &header, &info) == 0);
     assert(parser.buffer_length == 0);
-    assert(info.lamports == 42);
-    assert(memcmp(fee_payer_pubkey, info.from, PUBKEY_SIZE) == 0);
+    assert(info.transfer.lamports == 42);
+    assert(memcmp(fee_payer_pubkey, info.transfer.from, PUBKEY_SIZE) == 0);
 }
 
 void test_parse_system_transfer_instructions_with_payer() {
@@ -31,11 +31,11 @@ void test_parse_system_transfer_instructions_with_payer() {
     assert(parse_instruction(&parser, &instruction) == 0);
 
     Pubkey* fee_payer_pubkey = &header.pubkeys[0];
-    SystemTransferInfo info;
-    assert(parse_system_transfer_instructions(&parser, &instruction, &header, &info) == 0);
+    SystemInfo info;
+    assert(parse_system_instructions(&instruction, &header, &info) == 0);
 
     // "to", not "from", is paying for this transaction.
-    assert(memcmp(fee_payer_pubkey, info.to, PUBKEY_SIZE) == 0);
+    assert(memcmp(fee_payer_pubkey, info.transfer.to, PUBKEY_SIZE) == 0);
 }
 
 
@@ -50,9 +50,9 @@ void test_process_system_transfer() {
 
     field_t fields[5];
     size_t fields_used;
-    SystemTransferInfo info;
-    assert(parse_system_transfer_instructions(&parser, &instruction, &header, &info) == 0);
-    assert(print_system_transfer_info(&info, &header, fields, &fields_used) == 0);
+    SystemInfo info;
+    assert(parse_system_instructions(&instruction, &header, &info) == 0);
+    assert(print_system_info(&info, &header, fields, &fields_used) == 0);
     assert_string_equal(fields[0].text, "0.000000042 SOL");
 
     // Fee-payer is sender


### PR DESCRIPTION
#### Problem

Replicode. Instruction kind is parsed per-instruction

#### Changes

Add delegation functions for each program to parse instruction kind and steer to the correct parser/printer