### PR TITLE
Move `BAIL_IF` to a util header

### DIFF
--- a/libsol/instruction.c
+++ b/libsol/instruction.c
@@ -1,9 +1,8 @@
 #include "instruction.h"
 #include "stake_instruction.h"
 #include "system_instruction.h"
+#include "util.h"
 #include <string.h>
-
-#define BAIL_IF(x) {int err = x; if (err) return err;}
 
 enum ProgramId instruction_program_id(const Instruction* instruction, const MessageHeader* header) {
     const Pubkey* program_id = &header->pubkeys[instruction->program_id_index];

--- a/libsol/message.c
+++ b/libsol/message.c
@@ -4,8 +4,7 @@
 #include "sol/message.h"
 #include "system_instruction.h"
 #include "stake_instruction.h"
-
-#define BAIL_IF(x) {int err = x; if (err) return err;}
+#include "util.h"
 
 int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header, field_t* fields, size_t* fields_used) {
     BAIL_IF(header->instructions_length != 1);

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -1,9 +1,9 @@
 #include "message.c"
 #include "sol/printer.h"
+#include "util.h"
 #include <assert.h>
 #include <stdio.h>
 
-#define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 void test_process_message_body_ok() {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},

--- a/libsol/parser.c
+++ b/libsol/parser.c
@@ -1,6 +1,5 @@
 #include "sol/parser.h"
-
-#define BAIL_IF(x) {int err = x; if (err) return err;}
+#include "util.h"
 
 static int check_buffer_length(Parser* parser, size_t num) {
     return parser->buffer_length < num ? 1 : 0;

--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -1,9 +1,8 @@
 #include "sol/parser.h"
 #include "sol/printer.h"
 #include "stake_instruction.h"
+#include "util.h"
 #include <string.h>
-
-#define BAIL_IF(x) {int err = x; if (err) return err;}
 
 // Stake11111111111111111111111111111111111111
 const Pubkey stake_program_id = {{

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -1,9 +1,8 @@
 #include "sol/parser.h"
 #include "sol/printer.h"
 #include "system_instruction.h"
+#include "util.h"
 #include <string.h>
-
-#define BAIL_IF(x) {int err = x; if (err) return err;}
 
 const Pubkey system_program_id = {{
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/libsol/util.h
+++ b/libsol/util.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
+#define BAIL_IF(x) {int err = x; if (err) return err;}


### PR DESCRIPTION
#### Problem

Replicode.  More `BAIL_IF`'s than the county jail

#### Changes

Move them to a util header (I'll use it responsibly, I promise :innocent:)