### PR TITLE
Be strict when deserializing enums

### DIFF
--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -13,7 +13,20 @@ const Pubkey stake_program_id = {{
 }};
 
 static int parse_stake_instruction_kind(Parser* parser, enum StakeInstructionKind* kind) {
-    return parse_u32(parser, (uint32_t *) kind);
+    uint32_t maybe_kind;
+    BAIL_IF(parse_u32(parser, &maybe_kind));
+    switch (maybe_kind) {
+        case Initialize:
+        case Authorize:
+        case DelegateStake:
+        case Split:
+        case Withdraw:
+        case Deactivate:
+        case SetLockup:
+            *kind = (enum StakeInstructionKind) maybe_kind;
+            return 0;
+    }
+    return 1;
 }
 
 // Returns 0 and populates DelegateStakeInfo if provided a MessageHeader and a delegate

--- a/libsol/stake_instruction_test.c
+++ b/libsol/stake_instruction_test.c
@@ -18,6 +18,65 @@ void test_parse_delegate_stake_instructions() {
     assert(parser.buffer_length == 0);
 }
 
+void test_parse_stake_instruction_kind() {
+    enum StakeInstructionKind kind;
+    uint8_t buf[] = {0, 0, 0, 0};
+    Parser parser = {buf, ARRAY_LEN(buf)};
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Initialize);
+
+    buf[0] = 1;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Authorize);
+
+    buf[0] = 2;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == DelegateStake);
+
+    buf[0] = 3;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Split);
+
+    buf[0] = 4;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Withdraw);
+
+    buf[0] = 5;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Deactivate);
+
+    buf[0] = 6;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 0);
+    assert(kind == SetLockup);
+
+    // Fail the first unused enum value to be sure this test gets updated
+    buf[0] = 7;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 1);
+
+    // Should always fail
+    buf[0] = 255;
+    buf[1] = 255;
+    buf[2] = 255;
+    buf[3] = 255;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_instruction_kind(&parser, &kind) == 1);
+}
+
 int main() {
     test_parse_delegate_stake_instructions();
 

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -10,7 +10,24 @@ const Pubkey system_program_id = {{
 }};
 
 static int parse_system_instruction_kind(Parser* parser, enum SystemInstructionKind* kind) {
-    return parse_u32(parser, (uint32_t *) kind);
+    uint32_t maybe_kind;
+    BAIL_IF(parse_u32(parser, &maybe_kind));
+    switch (maybe_kind) {
+        case CreateAccount:
+        case Assign:
+        case Transfer:
+        case CreateAccountWithSeed:
+        case AdvanceNonceAccount:
+        case WithdrawNonceAccount:
+        case InitializeNonceAccount:
+        case AuthorizeNonceAccount:
+        case Allocate:
+        case AllocateWithSeed:
+        case AssignWithSeed:
+            *kind = (enum SystemInstructionKind) maybe_kind;
+            return 0;
+    }
+    return 1;
 }
 
 // Returns 0 and populates SystemTransferInfo if provided a MessageHeader and a transfer

--- a/libsol/system_instruction_test.c
+++ b/libsol/system_instruction_test.c
@@ -63,6 +63,89 @@ void test_process_system_transfer() {
     assert_string_equal(fields[3].text, "sender");
 }
 
+void test_parse_system_instruction_kind() {
+    enum SystemInstructionKind kind;
+    uint8_t buf[] = {0, 0, 0, 0};
+    Parser parser = {buf, ARRAY_LEN(buf)};
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == CreateAccount);
+
+    buf[0] = 1;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Assign);
+
+    buf[0] = 2;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Transfer);
+
+    buf[0] = 3;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == CreateAccountWithSeed);
+
+    buf[0] = 4;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == AdvanceNonceAccount);
+
+    buf[0] = 5;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == WithdrawNonceAccount);
+
+    buf[0] = 6;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == InitializeNonceAccount);
+
+    buf[0] = 7;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == AuthorizeNonceAccount);
+
+    buf[0] = 8;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == Allocate);
+
+    buf[0] = 9;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == AllocateWithSeed);
+
+    buf[0] = 10;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 0);
+    assert(kind == AssignWithSeed);
+
+    // Fail the first unused enum value to be sure this test gets updated
+    buf[0] = 11;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 1);
+
+    // Should always fail
+    buf[0] = 255;
+    buf[1] = 255;
+    buf[2] = 255;
+    buf[3] = 255;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_system_instruction_kind(&parser, &kind) == 1);
+}
+
 int main() {
     test_parse_system_transfer_instructions();
     test_parse_system_transfer_instructions_with_payer();


### PR DESCRIPTION
#### Problem

Enum deserialization doesn't check that the integer value is actually a variant of the type

#### Changes

Check variants