### PR TITLE
Split parse and print while processing messages

### DIFF
--- a/libsol/instruction.h
+++ b/libsol/instruction.h
@@ -1,12 +1,22 @@
 #pragma once
 
 #include "sol/parser.h"
+#include "stake_instruction.h"
+#include "system_instruction.h"
 
 enum ProgramId {
     ProgramIdUnknown = 0,
     ProgramIdStake,
     ProgramIdSystem,
 };
+
+typedef struct InstructionInfo {
+    enum ProgramId kind;
+    union {
+        StakeInfo stake;
+        SystemInfo system;
+    };
+} InstructionInfo;
 
 enum ProgramId instruction_program_id(const Instruction* instruction, const MessageHeader* header);
 int instruction_validate(const Instruction* instruction, const MessageHeader* header);

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -38,13 +38,15 @@ void test_process_message_body_too_many_ix_fail() {
 
 void test_process_message_body_too_short_ix_fail() {
     MessageHeader header = {{0, 0, 0, 0}, NULL, NULL, 1};
-    assert(process_message_body(NULL, 0, &header, NULL, NULL) == 1);
+    size_t fields_used = 0;
+    assert(process_message_body(NULL, 0, &header, NULL, &fields_used) == 1);
 }
 
 void test_process_message_body_bad_ix_account_index_fail() {
     MessageHeader header = {{0, 0, 0, 1}, NULL, NULL, 1};
     uint8_t msg_body[] = {1, 0, 0};
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, NULL) == 1);
+    size_t fields_used = 0;
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, &fields_used) == 1);
 }
 
 int main() {


### PR DESCRIPTION
#### Problem

To handle multiple instructions, we'll need to inspect  the instruction stream to decide what needs displayed.  This can't be done at present as an instruction is displayed immediately upon being successfully parsed

#### Changes

Split parsing and printing into two separate steps