### PR TITLE
Explicitly upcast before shifting in uintX_t parsers

### DIFF
--- a/libsol/parser.c
+++ b/libsol/parser.c
@@ -21,7 +21,7 @@ static int parse_u16(Parser* parser, uint16_t* value) {
     uint8_t lower, upper;
     BAIL_IF(parse_u8(parser, &lower));
     BAIL_IF(parse_u8(parser, &upper));
-    *value = lower + (upper << 8);
+    *value = lower + ((uint16_t)upper << 8);
     return 0;
 }
 
@@ -29,7 +29,7 @@ int parse_u32(Parser* parser, uint32_t* value) {
     uint16_t lower, upper;
     BAIL_IF(parse_u16(parser, &lower));
     BAIL_IF(parse_u16(parser, &upper));
-    *value = lower + (upper << 16);
+    *value = lower + ((uint32_t)upper << 16);
     return 0;
 }
 

--- a/libsol/parser_test.c
+++ b/libsol/parser_test.c
@@ -21,6 +21,42 @@ void test_parse_u8_too_short() {
    assert(parse_u8(&parser, &value) == 1);
 }
 
+void test_parse_u16() {
+   uint8_t message[] = {0, 0, 255, 255};
+   Parser parser = {message, sizeof(message)};
+   uint16_t value;
+   assert(parse_u16(&parser, &value) == 0);
+   assert(value == 0);
+   assert(parse_u16(&parser, &value) == 0);
+   assert(value == UINT16_MAX);
+   assert(parser_is_empty(&parser));
+}
+
+void test_parse_u32() {
+   uint8_t message[] = {0, 0, 0, 0, 255, 255, 255, 255};
+   Parser parser = {message, sizeof(message)};
+   uint32_t value;
+   assert(parse_u32(&parser, &value) == 0);
+   assert(value == 0);
+   assert(parse_u32(&parser, &value) == 0);
+   assert(value == UINT32_MAX);
+   assert(parser_is_empty(&parser));
+}
+
+void test_parse_u64() {
+   uint8_t message[] = {
+      0, 0, 0, 0, 0, 0, 0, 0,
+      255, 255, 255, 255, 255, 255, 255, 255
+   };
+   Parser parser = {message, sizeof(message)};
+   uint64_t value;
+   assert(parse_u64(&parser, &value) == 0);
+   assert(value == 0);
+   assert(parse_u64(&parser, &value) == 0);
+   assert(value == UINT64_MAX);
+   assert(parser_is_empty(&parser));
+}
+
 void test_parse_length() {
    uint8_t message[] = {1, 2};
    Parser parser = {message, sizeof(message)};
@@ -129,6 +165,9 @@ void test_parser_is_empty() {
 int main() {
     test_parse_u8();
     test_parse_u8_too_short();
+    test_parse_u16();
+    test_parse_u32();
+    test_parse_u64();
     test_parse_length();
     test_parse_length_two_bytes();
     test_parse_pubkeys_header();


### PR DESCRIPTION
#### Problem

Runtime error when shifting out of the type's range in uintX_t parsers

#### Changes

Explicitly upcast before shifting
Add tests