### PR TITLE
FieldsUsed resilience

### DIFF
--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -160,6 +160,9 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     case 4:
         ux_flow_init(0, ux_4_fields, NULL);
         break;
+    default:
+        THROW(0x6f00);
+        return;
     }
 
     *flags |= IO_ASYNCH_REPLY;

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -140,7 +140,7 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     encode_base58((uint8_t*) &header.pubkeys[0], PUBKEY_LENGTH, (uint8_t*) pubkeyBuffer, BASE58_PUBKEY_LENGTH);
     print_summary(pubkeyBuffer, G_fields[3].text, SUMMARY_LENGTH, SUMMARY_LENGTH);
 
-    size_t fieldsUsed;
+    size_t fieldsUsed = 0;
     if (process_message_body(parser.buffer, parser.buffer_length, &header, G_fields, &fieldsUsed)) {
         strcpy(G_fields[0].title, "Unrecognized");
         strcpy(G_fields[0].text, "format");


### PR DESCRIPTION
#### Problem

Returning an unhandled `fieldsUsed` value to `signMessage()` fails silently

#### Changes

- Throw an internal error in this case
- Initialize `fieldsUsed`