### PR TITLE
Support for nonced single-instruction transactions

### DIFF
--- a/libsol/instruction.c
+++ b/libsol/instruction.c
@@ -22,3 +22,14 @@ int instruction_validate(const Instruction* instruction, const MessageHeader* he
     }
     return 0;
 }
+
+bool instruction_info_matches_brief(const InstructionInfo* info, const InstructionBrief* brief) {
+    if (brief->program_id == info->kind) {
+        switch (brief->program_id) {
+            case ProgramIdStake: return (brief->stake == info->stake.kind);
+            case ProgramIdSystem: return (brief->system == info->system.kind);
+            case ProgramIdUnknown: break;
+        }
+    }
+    return false;
+}

--- a/libsol/instruction.h
+++ b/libsol/instruction.h
@@ -3,6 +3,7 @@
 #include "sol/parser.h"
 #include "stake_instruction.h"
 #include "system_instruction.h"
+#include <stdbool.h>
 
 enum ProgramId {
     ProgramIdUnknown = 0,
@@ -20,3 +21,17 @@ typedef struct InstructionInfo {
 
 enum ProgramId instruction_program_id(const Instruction* instruction, const MessageHeader* header);
 int instruction_validate(const Instruction* instruction, const MessageHeader* header);
+
+
+typedef struct InstructionBrief {
+    enum ProgramId program_id;
+    union {
+        enum SystemInstructionKind system;
+        enum StakeInstructionKind stake;
+    };
+} InstructionBrief;
+
+#define SYSTEM_IX_BRIEF(system_ix) { ProgramIdSystem, .system = (system_ix) }
+#define STAKE_IX_BRIEF(stake_ix) { ProgramIdStake, .stake = (stake_ix) }
+
+bool instruction_info_matches_brief(const InstructionInfo* info, const InstructionBrief* brief);

--- a/libsol/instruction_test.c
+++ b/libsol/instruction_test.c
@@ -58,6 +58,29 @@ void test_instruction_validate_bad_last_account_index_fail() {
     assert(instruction_validate(&instruction, &header) == 1);
 }
 
+void test_static_brief_initializer_macros() {
+    InstructionBrief system_test = SYSTEM_IX_BRIEF(Transfer);
+    InstructionBrief system_expect = { ProgramIdSystem, .system = Transfer };
+    assert(memcmp(&system_test, &system_expect, sizeof(InstructionBrief)) == 0);
+    InstructionBrief stake_test = STAKE_IX_BRIEF(DelegateStake);
+    InstructionBrief stake_expect = { ProgramIdStake, .stake = DelegateStake };
+    assert(memcmp(&stake_test, &stake_expect, sizeof(InstructionBrief)) == 0);
+}
+
+void test_instruction_info_matches_brief() {
+    InstructionInfo info = {
+        .kind = ProgramIdSystem,
+        .system = {
+            .kind = Transfer,
+            .transfer = { NULL, NULL, 0 },
+        },
+    };
+    InstructionBrief brief_pass = SYSTEM_IX_BRIEF(Transfer);
+    assert(instruction_info_matches_brief(&info, &brief_pass));
+    InstructionBrief brief_fail = SYSTEM_IX_BRIEF(AdvanceNonceAccount);
+    assert(!instruction_info_matches_brief(&info, &brief_fail));
+}
+
 int main() {
     test_instruction_validate_ok();
     test_instruction_validate_bad_program_id_index_fail();
@@ -66,6 +89,8 @@ int main() {
     test_instruction_program_id_unknown();
     test_instruction_program_id_stake();
     test_instruction_program_id_system();
+    test_static_brief_initializer_macros();
+    test_instruction_info_matches_brief();
 
     printf("passed\n");
     return 0;

--- a/libsol/message.c
+++ b/libsol/message.c
@@ -7,7 +7,7 @@
 #include "util.h"
 #include <string.h>
 
-#define MAX_INSTRUCTIONS 1
+#define MAX_INSTRUCTIONS 2
 
 int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header, field_t* fields, size_t* fields_used) {
     BAIL_IF(header->instructions_length == 0);
@@ -53,13 +53,30 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
         BAIL_IF(instruction_info[i].kind == ProgramIdUnknown);
     }
 
-    InstructionInfo* info = &instruction_info[0];
-    switch (info->kind) {
-        case ProgramIdSystem:
-            return print_system_info(&info->system, header, fields, fields_used);
-        case ProgramIdStake:
-            return print_stake_info(&info->stake, header, fields, fields_used);
-        case ProgramIdUnknown:
+    size_t operative_ix = 0;
+    InstructionInfo* info = &instruction_info[operative_ix];
+    if (instruction_count > 1) {
+        InstructionBrief nonce_brief = SYSTEM_IX_BRIEF(AdvanceNonceAccount);
+        if (instruction_info_matches_brief(info, &nonce_brief)) {
+            print_system_nonced_transaction_sentinel(&info->system, header, fields, fields_used);
+            operative_ix++;
+            instruction_count--;
+            info = &instruction_info[operative_ix];
+        }
+    }
+
+    switch (instruction_count) {
+        case 1:
+            switch (info->kind) {
+                case ProgramIdSystem:
+                    return print_system_info(&info->system, header, fields, fields_used);
+                case ProgramIdStake:
+                    return print_stake_info(&info->stake, header, fields, fields_used);
+                case ProgramIdUnknown:
+                    break;
+            }
+            break;
+        default:
             break;
     }
 

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -50,11 +50,17 @@ void test_process_message_body_too_many_ix_fail() {
         {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
     };
     Blockhash blockhash = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
-    uint8_t msg_body[] = {
-        2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0,
-        2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0,
-    };
-    MessageHeader header = {{1, 0, 1, 3}, accounts, &blockhash, 2};
+    uint8_t xfer_ix[] = {2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0};
+
+#define TOO_MANY_IX (MAX_INSTRUCTIONS + 1)
+#define XFER_IX_LEN ARRAY_LEN(xfer_ix)
+
+    uint8_t msg_body[TOO_MANY_IX * XFER_IX_LEN];
+    for (size_t i = 0; i < TOO_MANY_IX; i++) {
+        uint8_t* start = msg_body + (i * XFER_IX_LEN);
+        memcpy(start, xfer_ix, XFER_IX_LEN);
+    }
+    MessageHeader header = {{1, 0, 1, 3}, accounts, &blockhash, TOO_MANY_IX};
     field_t fields[5];
     size_t fields_used = 0;
     assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 1);

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -19,6 +19,24 @@ void test_process_message_body_ok() {
     assert(fields_used == 4);
 }
 
+void test_process_message_body_xfer_w_nonce_ok() {
+    Pubkey accounts[] = {
+        {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
+        {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
+        {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+    };
+    Blockhash blockhash = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+    MessageHeader header = {{1, 0, 1, 3}, accounts, &blockhash, 2};
+    uint8_t msg_body[] = {
+        2, 3, 0, 1, 0, 4, 4, 0, 0, 0, // Nonce
+        2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0
+    };
+    field_t fields[6];
+    size_t fields_used = 0;
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 0);
+    assert(fields_used == 6);
+}
+
 void test_process_message_body_too_few_ix_fail() {
     MessageHeader header = {{0, 0, 0, 0}, NULL, NULL, 0};
     size_t fields_used = 0;
@@ -113,6 +131,7 @@ int main() {
     test_process_message_body_bad_ix_account_index_fail();
     test_process_message_body_unknown_ix_enum_fail();
     test_process_message_body_ix_with_unknown_program_id_fail();
+    test_process_message_body_xfer_w_nonce_ok();
 
     printf("passed\n");
     return 0;

--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -102,7 +102,7 @@ static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* hea
         strcpy(fields[3].text, "authorizer");
     }
 
-    *fields_used = 4;
+    *fields_used += 4;
     return 0;
 }
 

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -117,7 +117,7 @@ static int print_system_transfer_info(SystemTransferInfo* info, MessageHeader* h
         strcpy(fields[3].text, "sender");
     }
 
-    *fields_used = 4;
+    *fields_used += 4;
     return 0;
 }
 
@@ -139,7 +139,7 @@ static int print_system_advance_nonce_account(SystemAdvanceNonceInfo* info, Mess
         print_summary(pubkey_buffer, fields[3].text, SUMMARY_LENGTH, SUMMARY_LENGTH);
     }
 
-    *fields_used = 3;
+    *fields_used += 3;
     return 0;
 }
 
@@ -162,4 +162,18 @@ int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, 
     }
 
     return 1;
+}
+
+int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
+    SystemAdvanceNonceInfo* nonce_info = &info->advance_nonce;
+    char pubkey_buffer[BASE58_PUBKEY_LENGTH];
+
+    encode_base58((uint8_t*) nonce_info->account, PUBKEY_SIZE, (uint8_t*) pubkey_buffer, BASE58_PUBKEY_LENGTH);
+    print_summary(pubkey_buffer, fields[4].text, SUMMARY_LENGTH, SUMMARY_LENGTH);
+
+    encode_base58((uint8_t*) nonce_info->authority, PUBKEY_SIZE, (uint8_t*) pubkey_buffer, BASE58_PUBKEY_LENGTH);
+    print_summary(pubkey_buffer, fields[5].text, SUMMARY_LENGTH, SUMMARY_LENGTH);
+
+    *fields_used += 2;
+    return 0;
 }

--- a/libsol/system_instruction.h
+++ b/libsol/system_instruction.h
@@ -40,3 +40,4 @@ typedef struct SystemInfo {
 
 int parse_system_instructions(Instruction* instruction, MessageHeader* header, SystemInfo* info);
 int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
+int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -7,7 +7,7 @@
 #include "sol/printer.h"
 #include "sol/message.h"
 
-static field_t G_fields[4];
+static field_t G_fields[6];
 
 static uint8_t G_message[MAX_MESSAGE_LENGTH];
 static int G_messageLength;
@@ -61,6 +61,20 @@ UX_STEP_NOCB(
       .title = "Fee paid by",
       .text = G_fields[3].text,
     });
+UX_STEP_NOCB(
+    ux_nonce_account_step,
+    bnnn_paging,
+    {
+      .title = "Nonce account",
+      .text = G_fields[4].text,
+    });
+UX_STEP_NOCB(
+    ux_nonce_authority_step,
+    bnnn_paging,
+    {
+      .title = "Nonce authority",
+      .text = G_fields[5].text,
+    });
 UX_STEP_VALID(
     ux_approve_step,
     pb,
@@ -91,6 +105,17 @@ UX_FLOW(ux_4_fields,
   &ux_sender_step,
   &ux_recipient_step,
   &ux_fee_payer_step,
+  &ux_approve_step,
+  &ux_reject_step
+);
+
+UX_FLOW(ux_6_fields,
+  &ux_instruction_step,
+  &ux_sender_step,
+  &ux_recipient_step,
+  &ux_fee_payer_step,
+  &ux_nonce_account_step,
+  &ux_nonce_authority_step,
   &ux_approve_step,
   &ux_reject_step
 );
@@ -159,6 +184,9 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
         break;
     case 4:
         ux_flow_init(0, ux_4_fields, NULL);
+        break;
+    case 6:
+        ux_flow_init(0, ux_6_fields, NULL);
         break;
     default:
         THROW(0x6f00);


### PR DESCRIPTION
#### Problem

No notion of nonced transactions

#### Changes

Add helpers for matching specific `InstructionInfo`s + tests
Add printing facilites for nonce TX sentinel instruction
Parse parse nonce TX sentinel instruction
Integration tests