### PR TITLE
Actually call ix kind test...

### DIFF
--- a/libsol/stake_instruction_test.c
+++ b/libsol/stake_instruction_test.c
@@ -79,6 +79,7 @@ void test_parse_stake_instruction_kind() {
 
 int main() {
     test_parse_delegate_stake_instructions();
+    test_parse_stake_instruction_kind();
 
     printf("passed\n");
     return 0;


### PR DESCRIPTION
#### Problem

We're not actually calling the function that tests stake instruction kind parsing

#### Changes

Call it