### PR TITLE
Rename Blockhash for generality

### DIFF
--- a/libsol/include/sol/parser.h
+++ b/libsol/include/sol/parser.h
@@ -4,7 +4,8 @@
 #include <stddef.h>
 
 #define PUBKEY_SIZE 32
-#define BLOCKHASH_SIZE PUBKEY_SIZE
+#define HASH_SIZE 32
+#define BLOCKHASH_SIZE HASH_SIZE
 
 typedef struct Parser {
     uint8_t* buffer;
@@ -15,9 +16,10 @@ typedef struct Pubkey {
     uint8_t data[PUBKEY_SIZE];
 } Pubkey;
 
-typedef struct Blockhash {
-    uint8_t data[BLOCKHASH_SIZE];
-} Blockhash;
+typedef struct Hash {
+    uint8_t data[HASH_SIZE];
+} Hash;
+typedef struct Hash Blockhash;
 
 typedef struct Instruction {
     uint8_t program_id_index;
@@ -55,7 +57,8 @@ int parse_pubkeys_header(Parser* parser, PubkeysHeader* header);
 
 int parse_pubkeys(Parser* parser, PubkeysHeader* header, Pubkey** pubkeys);
 
-int parse_blockhash(Parser* parser, Blockhash** blockhash);
+int parse_blockhash(Parser* parser, Hash** hash);
+#define parse_blockhash parse_hash
 
 int parse_message_header(Parser* parser, MessageHeader* header);
 

--- a/libsol/parser.c
+++ b/libsol/parser.c
@@ -75,10 +75,10 @@ int parse_pubkeys(Parser* parser, PubkeysHeader* header, Pubkey** pubkeys) {
     return 0;
 }
 
-int parse_blockhash(Parser* parser, Blockhash** blockhash) {
-    BAIL_IF(check_buffer_length(parser, BLOCKHASH_SIZE));
-    *blockhash = (Blockhash*) parser->buffer;
-    advance(parser, BLOCKHASH_SIZE);
+int parse_hash(Parser* parser, Hash** hash) {
+    BAIL_IF(check_buffer_length(parser, HASH_SIZE));
+    *hash = (Hash*) parser->buffer;
+    advance(parser, HASH_SIZE);
     return 0;
 }
 

--- a/libsol/parser_test.c
+++ b/libsol/parser_test.c
@@ -106,21 +106,21 @@ void test_parse_pubkeys_too_short() {
    assert(parse_pubkeys(&parser, &header, &pubkeys) == 1);
 }
 
-void test_parse_blockhash() {
-   uint8_t message[BLOCKHASH_SIZE] = {42};
+void test_parse_hash() {
+   uint8_t message[HASH_SIZE] = {42};
    Parser parser = {message, sizeof(message)};
-   Blockhash* blockhash;
-   assert(parse_blockhash(&parser, &blockhash) == 0);
+   Hash* hash;
+   assert(parse_hash(&parser, &hash) == 0);
    assert(parser_is_empty(&parser));
-   assert(parser.buffer == message + BLOCKHASH_SIZE);
-   assert(blockhash->data[0] == 42);
+   assert(parser.buffer == message + HASH_SIZE);
+   assert(hash->data[0] == 42);
 }
 
-void test_parse_blockhash_too_short() {
+void test_parse_hash_too_short() {
    uint8_t message[31]; // <--- Too short!
    Parser parser = {message, sizeof(message)};
-   Blockhash* blockhash;
-   assert(parse_blockhash(&parser, &blockhash) == 1);
+   Hash* hash;
+   assert(parse_hash(&parser, &hash) == 1);
 }
 
 void test_parse_data() {
@@ -173,8 +173,8 @@ int main() {
     test_parse_pubkeys_header();
     test_parse_pubkeys();
     test_parse_pubkeys_too_short();
-    test_parse_blockhash();
-    test_parse_blockhash_too_short();
+    test_parse_hash();
+    test_parse_hash_too_short();
     test_parse_data();
     test_parse_data_too_short();
     test_parse_instruction();


### PR DESCRIPTION
#### Problem

We have more than just block hashes, yet only a `Blockhash` type

#### Changes

Rename `Blockhash` to `Hash`
Alias back to `Blockhash` for clarity