### PR TITLE
Add printer for u64 (non-amount)

### DIFF
--- a/libsol/include/sol/printer.h
+++ b/libsol/include/sol/printer.h
@@ -14,6 +14,8 @@ typedef struct field_t {
 
 int print_amount(uint64_t amount, const char *asset, char *out);
 
+int print_u64(uint64_t u64, char* out, int outlen);
+
 int print_summary(const char *in, char *out, uint8_t left_length, uint8_t right_length);
 
 int encode_base58(uint8_t *in, uint8_t length, uint8_t *out, uint8_t maxoutlen);

--- a/libsol/printer.c
+++ b/libsol/printer.c
@@ -1,6 +1,7 @@
 #include <string.h>
-#include "sol/printer.h"
 #include "os_error.h"
+#include "sol/printer.h"
+#include "util.h"
 
 // max amount is max uint64 scaled down: "9223372036.854775807"
 #define AMOUNT_MAX_SIZE 22
@@ -114,5 +115,35 @@ int encode_base58(uint8_t *in, uint8_t length, uint8_t *out, uint8_t maxoutlen) 
     }
     memmove(out, (buffer + j), length);
     out[length] = '\0';
+    return 0;
+}
+
+int print_u64(uint64_t u64, char* out, int outlen) {
+    uint64_t dVal = u64;
+    int i = 0;
+    int j = 0;
+
+    if (i < (outlen - 1)) {
+        do {
+            if (dVal > 0) {
+                out[i] = (dVal % 10) + '0';
+                dVal /= 10;
+            } else {
+                out[i] = '0';
+            }
+            i++;
+        } while (dVal > 0 && i < outlen);
+    }
+
+    BAIL_IF(i >= outlen);
+
+    out[i--] = '\0';
+
+    for (; j < i; j++, i--) {
+        int tmp = out[j];
+        out[j] = out[i];
+        out[i] = tmp;
+    }
+
     return 0;
 }

--- a/libsol/printer_test.c
+++ b/libsol/printer_test.c
@@ -30,9 +30,23 @@ void test_print_summary() {
   assert_string_equal(summary, "GADFVW..LEQN2I");
 }
 
+void test_print_u64() {
+#define U64_MAX_STR (20 + 1) // strlen("18446744073709551615") + NUL
+    char out[U64_MAX_STR];
+
+    assert(print_u64(0, out, sizeof(out)) == 0);
+    assert_string_equal(out, "0");
+    assert(print_u64(UINT64_MAX, out, sizeof(out)) == 0);
+    assert_string_equal(out, "18446744073709551615");
+
+    assert(print_u64(UINT64_MAX, out, sizeof(out) - 1) == 1);
+    assert(print_u64(0, NULL, 0) == 1);
+}
+
 int main() {
     test_print_amount();
     test_print_summary();
+    test_print_u64();
 
     printf("passed\n");
     return 0;


### PR DESCRIPTION
#### Problem

No way to display `u64`s without formatting as SOL. BOLOS `snprintf()` is lame

#### Changes

Add simple string printer for `u64`
Test it