### PR TITLE
Low memory display facilities

### DIFF
--- a/libsol/include/sol/message.h
+++ b/libsol/include/sol/message.h
@@ -1,3 +1,3 @@
 #pragma once
 
-int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header, field_t* fields, size_t* fields_used);
+int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header);

--- a/libsol/include/sol/printer.h
+++ b/libsol/include/sol/printer.h
@@ -8,11 +8,6 @@
 #define BASE58_PUBKEY_LENGTH 45
 #define BASE58_PUBKEY_SHORT (SUMMARY_LENGTH + 2 + SUMMARY_LENGTH + 1)
 
-typedef struct field_t {
-    char title[TITLE_SIZE];
-    char text[BASE58_PUBKEY_LENGTH];
-} field_t;
-
 int print_amount(uint64_t amount, const char *asset, char *out, size_t out_length);
 
 int print_u64(uint64_t u64, char* out, size_t out_length);

--- a/libsol/include/sol/transaction_summary.h
+++ b/libsol/include/sol/transaction_summary.h
@@ -46,12 +46,16 @@ extern char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
 void transaction_summary_reset();
 int transaction_summary_display_item(size_t item_index);
 int transaction_summary_finalize(enum SummaryItemKind* item_kinds, size_t* item_kinds_len);
+
 // Get a pointer to the requested SummaryItem. NULL if it has already been set
 SummaryItem* transaction_summary_primary_item();
 SummaryItem* transaction_summary_fee_payer_item();
 SummaryItem* transaction_summary_nonce_account_item();
 SummaryItem* transaction_summary_nonce_authority_item();
 SummaryItem* transaction_summary_general_item();
+
+int transaction_summary_set_fee_payer_pubkey(Pubkey* pubkey);
+int transaction_summary_set_fee_payer_string(const char* string);
 
 // Assign type/title/value to a SummaryItem
 void summary_item_set_amount(SummaryItem* item, const char* title, uint64_t value);

--- a/libsol/include/sol/transaction_summary.h
+++ b/libsol/include/sol/transaction_summary.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "sol/parser.h"
+#include "sol/printer.h"
+
+// TransactionSummary management
+//
+// TransactionSummary sits behind a singleton and is expected to be accessed
+// via the following methods
+//
+// A TransactionSummary consists of several SummaryItems.  If set previously,
+// they will be displayed in the following order:
+//
+// primary          -- Required
+// general[0..N]    -- Optional
+// nonce_account    -- Optional
+// nonce_authority  -- Optional
+// fee_payer        -- Required
+//
+// If all _Required_ `SummaryItem`s have not been set, finalization will fail.
+
+#define NUM_GENERAL_ITEMS 2
+#define MAX_TRANSACTION_SUMMARY_ITEMS ( \
+    1       /* primary */               \
+    + NUM_GENERAL_ITEMS                 \
+    + 1     /* nonce_account */         \
+    + 1     /* nonce_authority */       \
+    + 1     /* fee_payer */             \
+)
+
+enum SummaryItemKind {
+    SummaryItemNone = 0, // SummaryItemNone always zero
+    SummaryItemAmount,
+    SummaryItemU64,
+    SummaryItemPubkey,
+    SummaryItemHash,
+    SummaryItemString,
+};
+
+typedef struct SummaryItem SummaryItem;
+
+extern char G_transaction_summary_title[TITLE_SIZE];
+#define TEXT_BUFFER_LENGTH BASE58_PUBKEY_LENGTH
+extern char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
+
+void transaction_summary_reset();
+int transaction_summary_display_item(size_t item_index);
+int transaction_summary_finalize(enum SummaryItemKind* item_kinds, size_t* item_kinds_len);
+// Get a pointer to the requested SummaryItem. NULL if it has already been set
+SummaryItem* transaction_summary_primary_item();
+SummaryItem* transaction_summary_fee_payer_item();
+SummaryItem* transaction_summary_nonce_account_item();
+SummaryItem* transaction_summary_nonce_authority_item();
+SummaryItem* transaction_summary_general_item();
+
+// Assign type/title/value to a SummaryItem
+void summary_item_set_amount(SummaryItem* item, const char* title, uint64_t value);
+void summary_item_set_u64(SummaryItem* item, const char* title, uint64_t value);
+void summary_item_set_pubkey(SummaryItem* item, const char* title, const Pubkey* value);
+void summary_item_set_hash(SummaryItem* item, const char* title, const Hash* value);
+void summary_item_set_string(SummaryItem* item, const char* title, const char* value);
+

--- a/libsol/message.c
+++ b/libsol/message.c
@@ -1,6 +1,5 @@
 #include "instruction.h"
 #include "sol/parser.h"
-#include "sol/printer.h"
 #include "sol/message.h"
 #include "system_instruction.h"
 #include "stake_instruction.h"
@@ -9,7 +8,7 @@
 
 #define MAX_INSTRUCTIONS 2
 
-int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header, field_t* fields, size_t* fields_used) {
+int process_message_body(uint8_t* message_body, int message_body_length, MessageHeader* header) {
     BAIL_IF(header->instructions_length == 0);
     BAIL_IF(header->instructions_length > MAX_INSTRUCTIONS);
 
@@ -71,7 +70,7 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
                 case ProgramIdSystem:
                     return print_system_info(&info->system, header);
                 case ProgramIdStake:
-                    return print_stake_info(&info->stake, header, fields, fields_used);
+                    return print_stake_info(&info->stake, header);
                 case ProgramIdUnknown:
                     break;
             }
@@ -80,6 +79,5 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
             break;
     }
 
-    *fields_used = 0;
     return 1;
 }

--- a/libsol/message.c
+++ b/libsol/message.c
@@ -58,7 +58,7 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
     if (instruction_count > 1) {
         InstructionBrief nonce_brief = SYSTEM_IX_BRIEF(AdvanceNonceAccount);
         if (instruction_info_matches_brief(info, &nonce_brief)) {
-            print_system_nonced_transaction_sentinel(&info->system, header, fields, fields_used);
+            print_system_nonced_transaction_sentinel(&info->system, header);
             operative_ix++;
             instruction_count--;
             info = &instruction_info[operative_ix];
@@ -69,7 +69,7 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
         case 1:
             switch (info->kind) {
                 case ProgramIdSystem:
-                    return print_system_info(&info->system, header, fields, fields_used);
+                    return print_system_info(&info->system, header);
                 case ProgramIdStake:
                     return print_stake_info(&info->stake, header, fields, fields_used);
                 case ProgramIdUnknown:

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -1,5 +1,4 @@
 #include "message.c"
-#include "sol/printer.h"
 #include "sol/transaction_summary.h"
 #include "util.h"
 #include <assert.h>
@@ -16,7 +15,7 @@ void test_process_message_body_ok() {
     uint8_t msg_body[] = {2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0};
 
     transaction_summary_reset();
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, NULL) == 0);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 0);
     enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
     size_t num_kinds;
     assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
@@ -36,7 +35,7 @@ void test_process_message_body_xfer_w_nonce_ok() {
         2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0
     };
     transaction_summary_reset();
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, NULL) == 0);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 0);
     enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
     size_t num_kinds;
     assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
@@ -45,8 +44,7 @@ void test_process_message_body_xfer_w_nonce_ok() {
 
 void test_process_message_body_too_few_ix_fail() {
     MessageHeader header = {{0, 0, 0, 0}, NULL, NULL, 0};
-    size_t fields_used = 0;
-    assert(process_message_body(NULL, 0, &header, NULL, &fields_used) == 1);
+    assert(process_message_body(NULL, 0, &header) == 1);
 }
 
 void test_process_message_body_too_many_ix_fail() {
@@ -67,15 +65,12 @@ void test_process_message_body_too_many_ix_fail() {
         memcpy(start, xfer_ix, XFER_IX_LEN);
     }
     MessageHeader header = {{1, 0, 1, 3}, accounts, &blockhash, TOO_MANY_IX};
-    field_t fields[5];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 1);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 1);
 }
 
 void test_process_message_body_data_too_short_fail() {
     MessageHeader header = {{0, 0, 0, 0}, NULL, NULL, 1};
-    size_t fields_used = 0;
-    assert(process_message_body(NULL, 0, &header, NULL, &fields_used) == 1);
+    assert(process_message_body(NULL, 0, &header) == 1);
 }
 
 void test_process_message_body_data_too_long_fail() {
@@ -90,16 +85,13 @@ void test_process_message_body_data_too_long_fail() {
         2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0,
         0
     };
-    field_t fields[5];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 1);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 1);
 }
 
 void test_process_message_body_bad_ix_account_index_fail() {
     MessageHeader header = {{0, 0, 0, 1}, NULL, NULL, 1};
     uint8_t msg_body[] = {1, 0, 0};
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, &fields_used) == 1);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 1);
 }
 
 void test_process_message_body_unknown_ix_enum_fail() {
@@ -113,9 +105,7 @@ void test_process_message_body_unknown_ix_enum_fail() {
     uint8_t msg_body[] = {
         2, 2, 0, 1, 12, 255, 255, 255, 255, 42, 0, 0, 0, 0, 0, 0, 0,
     };
-    field_t fields[5];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 1);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 1);
 }
 
 void test_process_message_body_ix_with_unknown_program_id_fail() {
@@ -129,9 +119,7 @@ void test_process_message_body_ix_with_unknown_program_id_fail() {
     uint8_t msg_body[] = {
         2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0,
     };
-    field_t fields[5];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 1);
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header) == 1);
 }
 
 int main() {

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -1,5 +1,6 @@
 #include "message.c"
 #include "sol/printer.h"
+#include "sol/transaction_summary.h"
 #include "util.h"
 #include <assert.h>
 #include <stdio.h>
@@ -13,10 +14,13 @@ void test_process_message_body_ok() {
     Blockhash blockhash = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
     MessageHeader header = {{1, 0, 1, 3}, accounts, &blockhash, 1};
     uint8_t msg_body[] = {2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0};
-    field_t fields[5];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 0);
-    assert(fields_used == 4);
+
+    transaction_summary_reset();
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, NULL) == 0);
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 4);
 }
 
 void test_process_message_body_xfer_w_nonce_ok() {
@@ -31,10 +35,12 @@ void test_process_message_body_xfer_w_nonce_ok() {
         2, 3, 0, 1, 0, 4, 4, 0, 0, 0, // Nonce
         2, 2, 0, 1, 12, 2, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0
     };
-    field_t fields[6];
-    size_t fields_used = 0;
-    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, fields, &fields_used) == 0);
-    assert(fields_used == 6);
+    transaction_summary_reset();
+    assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &header, NULL, NULL) == 0);
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 6);
 }
 
 void test_process_message_body_too_few_ix_fail() {

--- a/libsol/printer_test.c
+++ b/libsol/printer_test.c
@@ -2,8 +2,6 @@
 #include <assert.h>
 #include <stdio.h>
 
-#define assert_string_equal(actual, expected) assert(strcmp(actual, expected) == 0)
-
 void test_print_amount() {
   char printed[24];
   const char *asset = "SOL";

--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -98,7 +98,7 @@ static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* hea
 
     item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->authorized_pubkey, PUBKEY_SIZE) == 0) {
-        summary_item_set_string(item, "Fee payer", "authorizer");
+        transaction_summary_set_fee_payer_string("authorizer");
     }
 
     return 0;

--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -1,5 +1,5 @@
 #include "sol/parser.h"
-#include "sol/printer.h"
+#include "sol/transaction_summary.h"
 #include "stake_instruction.h"
 #include "util.h"
 #include <string.h>
@@ -84,32 +84,30 @@ int parse_stake_instructions(Instruction* instruction, MessageHeader* header, St
     return 1;
 }
 
-static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
-    char pubkey_buffer[BASE58_PUBKEY_LENGTH];
-    strcpy(fields[0].title, "Delegate from");
-    encode_base58(info->stake_pubkey, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[0].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* header) {
+    SummaryItem* item;
 
-    strcpy(fields[1].title, "Authorized by");
-    encode_base58(info->authorized_pubkey, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[1].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_primary_item();
+    summary_item_set_pubkey(item, "Delegate from", info->stake_pubkey);
 
-    strcpy(fields[2].title, "Vote account");
-    encode_base58(info->vote_pubkey, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[2].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_general_item();
+    summary_item_set_pubkey(item, "Authorized by", info->authorized_pubkey);
 
+    item = transaction_summary_general_item();
+    summary_item_set_pubkey(item, "Vote account", info->vote_pubkey);
+
+    item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->authorized_pubkey, PUBKEY_SIZE) == 0) {
-        strcpy(fields[3].text, "authorizer");
+        summary_item_set_string(item, "Fee payer", "authorizer");
     }
 
-    *fields_used += 4;
     return 0;
 }
 
-int print_stake_info(StakeInfo* info, MessageHeader* header, field_t*  fields, size_t* fields_used) {
+int print_stake_info(StakeInfo* info, MessageHeader* header) {
     switch (info->kind) {
         case DelegateStake:
-            return print_delegate_stake_info(&info->delegate_stake, header, fields, fields_used);
+            return print_delegate_stake_info(&info->delegate_stake, header);
         case Initialize:
         case Authorize:
         case Split:

--- a/libsol/stake_instruction.h
+++ b/libsol/stake_instruction.h
@@ -29,4 +29,4 @@ typedef struct StakeInfo {
 } StakeInfo;
 
 int parse_stake_instructions(Instruction* instruction, MessageHeader* header, StakeInfo* info);
-int print_stake_info(StakeInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
+int print_stake_info(StakeInfo* info, MessageHeader* header);

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -1,5 +1,5 @@
 #include "sol/parser.h"
-#include "sol/printer.h"
+#include "sol/transaction_summary.h"
 #include "system_instruction.h"
 #include "util.h"
 #include <string.h>
@@ -96,59 +96,51 @@ int parse_system_instructions(Instruction* instruction, MessageHeader* header, S
     return 1;
 }
 
-static int print_system_transfer_info(SystemTransferInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
-    strcpy(fields[0].title, "Transfer");
-    print_amount(info->lamports, "SOL", fields[0].text, BASE58_PUBKEY_LENGTH);
+static int print_system_transfer_info(SystemTransferInfo* info, MessageHeader* header) {
+    SummaryItem* item;
 
-    char pubkey_buffer[BASE58_PUBKEY_LENGTH];
-    strcpy(fields[1].title, "Sender");
-    encode_base58(info->from, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[1].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_primary_item();
+    summary_item_set_amount(item, "Transfer", info->lamports);
 
-    strcpy(fields[2].title, "Recipient");
-    encode_base58(info->to, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[2].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_general_item();
+    summary_item_set_pubkey(item, "Sender", info->from);
 
+    item = transaction_summary_general_item();
+    summary_item_set_pubkey(item, "Recipient", info->to);
+
+    item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->to, PUBKEY_SIZE) == 0) {
-        strcpy(fields[3].text, "recipient");
+        summary_item_set_string(item, "Fee Payer", "recipient");
+    } else if (memcmp(&header->pubkeys[0], info->from, PUBKEY_SIZE) == 0) {
+        summary_item_set_string(item, "Fee Payer", "sender");
     }
 
-    if (memcmp(&header->pubkeys[0], info->from, PUBKEY_SIZE) == 0) {
-        strcpy(fields[3].text, "sender");
-    }
-
-    *fields_used += 4;
     return 0;
 }
 
-static int print_system_advance_nonce_account(SystemAdvanceNonceInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
-    char pubkey_buffer[BASE58_PUBKEY_LENGTH];
+static int print_system_advance_nonce_account(SystemAdvanceNonceInfo* info, MessageHeader* header) {
+    SummaryItem* item;
 
-    strcpy(fields[0].title, "Advance Nonce");
-    encode_base58(info->account, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[0].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_primary_item();
+    summary_item_set_pubkey(item, "Advance Nonce", info->account);
 
-    strcpy(fields[1].title, "Authorized by");
-    encode_base58(info->authority, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[1].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_general_item();
+    summary_item_set_pubkey(item, "Authorized by", info->authority);
 
+    item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->authority, PUBKEY_SIZE) == 0) {
-        strcpy(fields[3].text, "authority");
-    } else {
-        encode_base58(&header->pubkeys[0], PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-        print_summary(pubkey_buffer, fields[3].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+        summary_item_set_string(item, "Fee Payer", "authority");
     }
 
-    *fields_used += 3;
     return 0;
 }
 
-int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
+int print_system_info(SystemInfo* info, MessageHeader* header) {
     switch (info->kind) {
         case Transfer:
-            return print_system_transfer_info(&info->transfer, header, fields, fields_used);
+            return print_system_transfer_info(&info->transfer, header);
         case AdvanceNonceAccount:
-            return print_system_advance_nonce_account(&info->advance_nonce, header, fields, fields_used);
+            return print_system_advance_nonce_account(&info->advance_nonce, header);
         case CreateAccount:
         case Assign:
         case CreateAccountWithSeed:
@@ -164,16 +156,15 @@ int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, 
     return 1;
 }
 
-int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used) {
+int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header) {
     SystemAdvanceNonceInfo* nonce_info = &info->advance_nonce;
-    char pubkey_buffer[BASE58_PUBKEY_LENGTH];
+    SummaryItem* item;
 
-    encode_base58(nonce_info->account, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[4].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_nonce_account_item();
+    summary_item_set_pubkey(item, "Nonce Account", nonce_info->account);
 
-    encode_base58(nonce_info->authority, PUBKEY_SIZE, pubkey_buffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkey_buffer, fields[5].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
+    item = transaction_summary_nonce_authority_item();
+    summary_item_set_pubkey(item, "Nonce Authority", nonce_info->authority);
 
-    *fields_used += 2;
     return 0;
 }

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -110,9 +110,9 @@ static int print_system_transfer_info(SystemTransferInfo* info, MessageHeader* h
 
     item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->to, PUBKEY_SIZE) == 0) {
-        summary_item_set_string(item, "Fee Payer", "recipient");
+        transaction_summary_set_fee_payer_string("recipient");
     } else if (memcmp(&header->pubkeys[0], info->from, PUBKEY_SIZE) == 0) {
-        summary_item_set_string(item, "Fee Payer", "sender");
+        transaction_summary_set_fee_payer_string("sender");
     }
 
     return 0;
@@ -129,7 +129,7 @@ static int print_system_advance_nonce_account(SystemAdvanceNonceInfo* info, Mess
 
     item = transaction_summary_fee_payer_item();
     if (memcmp(&header->pubkeys[0], info->authority, PUBKEY_SIZE) == 0) {
-        summary_item_set_string(item, "Fee Payer", "authority");
+        transaction_summary_set_fee_payer_string("authority");
     }
 
     return 0;

--- a/libsol/system_instruction.h
+++ b/libsol/system_instruction.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "sol/parser.h"
-#include "sol/printer.h"
 
 extern const Pubkey system_program_id;
 
@@ -39,5 +38,5 @@ typedef struct SystemInfo {
 } SystemInfo;
 
 int parse_system_instructions(Instruction* instruction, MessageHeader* header, SystemInfo* info);
-int print_system_info(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
-int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header, field_t* fields, size_t* fields_used);
+int print_system_info(SystemInfo* info, MessageHeader* header);
+int print_system_nonced_transaction_sentinel(SystemInfo* info, MessageHeader* header);

--- a/libsol/system_instruction_test.c
+++ b/libsol/system_instruction_test.c
@@ -77,19 +77,23 @@ void test_parse_system_advance_nonce_account_instruction() {
     assert(memcmp(info.account, &header.pubkeys[account_index], PUBKEY_SIZE) == 0);
     assert(memcmp(info.authority, &header.pubkeys[authority_index], PUBKEY_SIZE) == 0);
 
-    field_t fields[4];
-    size_t fields_used = 0;
-    assert(print_system_advance_nonce_account(&info, &header, fields, &fields_used) == 0);
-    assert(fields_used == 3);
+    transaction_summary_reset();
+    assert(print_system_advance_nonce_account(&info, &header) == 0);
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 3);
 
     SystemInfo info2;
     assert(parse_system_instructions(&instruction, &header, &info2) == 0);
     assert(memcmp(info.account, &header.pubkeys[account_index], PUBKEY_SIZE) == 0);
     assert(memcmp(info.authority, &header.pubkeys[authority_index], PUBKEY_SIZE) == 0);
 
-    fields_used = 0;
-    assert(print_system_info(&info2, &header, fields, &fields_used) == 0);
-    assert(fields_used == 3);
+    num_kinds = 0;
+    transaction_summary_reset();
+    assert(print_system_info(&info2, &header) == 0);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 3);
 }
 
 void test_process_system_transfer() {
@@ -102,15 +106,23 @@ void test_process_system_transfer() {
     assert(parse_instruction(&parser, &instruction) == 0);
     assert(instruction_validate(&instruction, &header) == 0);
 
-    field_t fields[5];
-    size_t fields_used;
     SystemInfo info;
     assert(parse_system_instructions(&instruction, &header, &info) == 0);
-    assert(print_system_info(&info, &header, fields, &fields_used) == 0);
-    assert_string_equal(fields[0].text, "0.000000042 SOL");
+
+    transaction_summary_reset();
+    assert(print_system_info(&info, &header) == 0);
+
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 4);
+
+    transaction_summary_display_item(0);
+    assert_string_equal(G_transaction_summary_text, "0.000000042 SOL");
 
     // Fee-payer is sender
-    assert_string_equal(fields[3].text, "sender");
+    transaction_summary_display_item(3);
+    assert_string_equal(G_transaction_summary_text, "sender");
 }
 
 void test_parse_system_instruction_kind() {

--- a/libsol/transaction_summary.c
+++ b/libsol/transaction_summary.c
@@ -1,0 +1,205 @@
+#include "sol/printer.h"
+#include "sol/transaction_summary.h"
+#include "util.h"
+#include <string.h>
+
+struct SummaryItem {
+    const char* title;
+    enum SummaryItemKind kind;
+    union {
+        uint64_t u64;
+        const Pubkey* pubkey;
+        const Hash* hash;
+        const char* string;
+    };
+};
+
+void summary_item_set_amount(SummaryItem* item, const char* title, uint64_t value) {
+    item->kind = SummaryItemAmount;
+    item->title = title;
+    item->u64 = value;
+}
+
+void summary_item_set_u64(SummaryItem* item, const char* title, uint64_t value) {
+    item->kind = SummaryItemU64;
+    item->title = title;
+    item->u64 = value;
+}
+
+void summary_item_set_pubkey(SummaryItem* item, const char* title, const Pubkey* value) {
+    item->kind = SummaryItemPubkey;
+    item->title = title;
+    item->pubkey = value;
+}
+
+void summary_item_set_hash(SummaryItem* item, const char* title, const Hash* value) {
+    item->kind = SummaryItemHash;
+    item->title = title;
+    item->hash = value;
+}
+
+void summary_item_set_string(SummaryItem* item, const char* title, const char* value) {
+    item->kind = SummaryItemString;
+    item->title = title;
+    item->string = value;
+}
+
+typedef struct TransactionSummary {
+    SummaryItem primary;
+    SummaryItem fee_payer;
+    SummaryItem nonce_account;
+    SummaryItem nonce_authority;
+    SummaryItem general[NUM_GENERAL_ITEMS];
+} TransactionSummary;
+
+static TransactionSummary G_transaction_summary;
+
+char G_transaction_summary_title[TITLE_SIZE];
+char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
+
+void transaction_summary_reset() {
+    memset(&G_transaction_summary, 0, sizeof(TransactionSummary));
+    memset(&G_transaction_summary_title, 0, TITLE_SIZE);
+    memset(&G_transaction_summary_text, 0, TEXT_BUFFER_LENGTH);
+}
+
+static SummaryItem* summary_item_as_unused(SummaryItem* item) {
+    if (item->kind == SummaryItemNone) {
+        return item;
+    }
+    return NULL;
+}
+
+SummaryItem* transaction_summary_primary_item() {
+    SummaryItem* item = &G_transaction_summary.primary;
+    return summary_item_as_unused(item);
+}
+
+SummaryItem* transaction_summary_fee_payer_item() {
+    SummaryItem* item = &G_transaction_summary.fee_payer;
+    return summary_item_as_unused(item);
+}
+
+SummaryItem* transaction_summary_nonce_account_item() {
+    SummaryItem* item = &G_transaction_summary.nonce_account;
+    return summary_item_as_unused(item);
+}
+
+SummaryItem* transaction_summary_nonce_authority_item() {
+    SummaryItem* item = &G_transaction_summary.nonce_authority;
+    return summary_item_as_unused(item);
+}
+
+SummaryItem* transaction_summary_general_item() {
+    for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        SummaryItem* item = &G_transaction_summary.general[i];
+        if (summary_item_as_unused(item) != NULL) {
+            return item;
+        }
+    }
+    return NULL;
+}
+
+static int transaction_summary_update_display_for_item(const SummaryItem* item) {
+    switch (item->kind) {
+        case SummaryItemNone:
+            return 1;
+        case SummaryItemAmount:
+            BAIL_IF(print_amount(item->u64, "SOL", G_transaction_summary_text, BASE58_PUBKEY_LENGTH));
+            break;
+        case SummaryItemU64:
+            BAIL_IF(print_u64(item->u64, G_transaction_summary_text, TEXT_BUFFER_LENGTH));
+            break;
+        case SummaryItemPubkey: {
+            char tmp_buf[BASE58_PUBKEY_LENGTH];
+            BAIL_IF(encode_base58(item->pubkey, PUBKEY_SIZE, tmp_buf, sizeof(tmp_buf)));
+            BAIL_IF(print_summary(tmp_buf, G_transaction_summary_text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH));
+            break;
+        }
+        case SummaryItemHash:
+            BAIL_IF(encode_base58(item->hash, BLOCKHASH_SIZE, G_transaction_summary_text, TEXT_BUFFER_LENGTH));
+            break;
+        case SummaryItemString:
+            strncpy(G_transaction_summary_text, item->string, TEXT_BUFFER_LENGTH);
+            break;
+    }
+    // TODO: Write a safe string printer...
+    strncpy(G_transaction_summary_title, item->title, TITLE_SIZE);
+    return 0;
+}
+
+int transaction_summary_display_item(size_t item_index) {
+    struct TransactionSummary* summary = &G_transaction_summary;
+    SummaryItem* item = NULL;
+    SummaryItem* maybe_item = &summary->primary;
+
+    do {
+        if (item_index-- == 0) {
+            item = maybe_item;
+            break;
+        }
+        for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+            maybe_item = &summary->general[i];
+            if (summary_item_as_unused(maybe_item) == NULL) {
+                if (item_index-- == 0) {
+                    item = maybe_item;
+                    break;
+                }
+            }
+        }
+        if (item != NULL) {
+            break;
+        }
+        maybe_item = &summary->nonce_account;
+        if ((summary_item_as_unused(maybe_item) == NULL) && (item_index-- == 0)) {
+            item = maybe_item;
+            break;
+        }
+        maybe_item = &summary->nonce_authority;
+        if ((summary_item_as_unused(maybe_item) == NULL) && (item_index-- == 0)) {
+            item = maybe_item;
+            break;
+        }
+        if (item_index-- == 0) {
+            item = &summary->fee_payer;
+            break;
+        }
+    } while (0);
+
+    if (item == NULL) {
+        return 1;
+    }
+
+    return transaction_summary_update_display_for_item(item);
+}
+
+#define SET_IF_USED(item, item_kinds, index)    \
+    do {                                        \
+        if (item.kind != SummaryItemNone) {     \
+            item_kinds[index++] = item.kind;    \
+        }                                       \
+    } while(0)
+
+int transaction_summary_finalize(enum SummaryItemKind* item_kinds, size_t* item_kinds_len) {
+    const TransactionSummary* summary = &G_transaction_summary;
+    size_t index = 0;
+
+    if ((summary->primary.kind == SummaryItemNone)
+        || (summary->fee_payer.kind == SummaryItemNone)
+    ) {
+        return 1;
+    }
+
+    SET_IF_USED(summary->primary, item_kinds, index);
+
+    for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        SET_IF_USED(summary->general[i], item_kinds, index);
+    }
+
+    SET_IF_USED(summary->nonce_account, item_kinds, index);
+    SET_IF_USED(summary->nonce_authority, item_kinds, index);
+    SET_IF_USED(summary->fee_payer, item_kinds, index);
+
+    *item_kinds_len = index;
+    return 0;
+}

--- a/libsol/transaction_summary.c
+++ b/libsol/transaction_summary.c
@@ -100,6 +100,21 @@ SummaryItem* transaction_summary_general_item() {
     return NULL;
 }
 
+#define FEE_PAYER_TITLE "Fee payer"
+int transaction_summary_set_fee_payer_pubkey(Pubkey* pubkey) {
+    SummaryItem* item = transaction_summary_fee_payer_item();
+    BAIL_IF(item == NULL);
+    summary_item_set_pubkey(item, FEE_PAYER_TITLE, pubkey);
+    return 0;
+}
+
+int transaction_summary_set_fee_payer_string(const char* string) {
+    SummaryItem* item = transaction_summary_fee_payer_item();
+    BAIL_IF(item == NULL);
+    summary_item_set_string(item, FEE_PAYER_TITLE, string);
+    return 0;
+}
+
 static int transaction_summary_update_display_for_item(const SummaryItem* item) {
     switch (item->kind) {
         case SummaryItemNone:

--- a/libsol/transaction_summary_test.c
+++ b/libsol/transaction_summary_test.c
@@ -273,7 +273,7 @@ void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug() {
     SummaryItem* item;
     const char* primary_title = "Unrecognized";
     const char* primary_text = "format";
-    const char* fee_payer_title = "Fee payer";
+    const char* fee_payer_title = FEE_PAYER_TITLE;
     const char* fee_payer_text = "1111111..1111111";
     Pubkey fee_payer = {{
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/libsol/transaction_summary_test.c
+++ b/libsol/transaction_summary_test.c
@@ -1,0 +1,333 @@
+#include "transaction_summary.c"
+#include <assert.h>
+#include <stdio.h>
+
+void test_summary_item_setters() {
+    SummaryItem item;
+
+    summary_item_set_amount(&item, "amount", 42);
+    assert(item.kind == SummaryItemAmount);
+    assert_string_equal(item.title, "amount");
+    assert(item.u64 == 42);
+
+    summary_item_set_u64(&item, "u64", 4242);
+    assert(item.kind == SummaryItemU64);
+    assert_string_equal(item.title, "u64");
+    assert(item.u64 == 4242);
+
+    Pubkey pubkey;
+    memset(&pubkey, 1, sizeof(Pubkey));
+    summary_item_set_pubkey(&item, "pubkey", &pubkey);
+    assert(item.kind == SummaryItemPubkey);
+    assert_string_equal(item.title, "pubkey");
+    assert(item.pubkey == &pubkey);
+
+    Hash hash;
+    memset(&hash, 2, sizeof(Hash));
+    summary_item_set_hash(&item, "hash", &hash);
+    assert(item.kind == SummaryItemHash);
+    assert_string_equal(item.title, "hash");
+    assert(item.hash == &hash);
+
+    const char* string = "value";
+    summary_item_set_string(&item, "string", string);
+    assert(item.kind == SummaryItemString);
+    assert_string_equal(item.title, "string");
+    assert(item.string == string);
+}
+
+void test_summary_item_as_unused() {
+    SummaryItem item;
+
+    item.kind = SummaryItemNone;
+    assert(summary_item_as_unused(&item) != NULL);
+
+    item.kind = SummaryItemAmount;
+    assert(summary_item_as_unused(&item) == NULL);
+
+    item.kind = SummaryItemU64;
+    assert(summary_item_as_unused(&item) == NULL);
+
+    item.kind = SummaryItemPubkey;
+    assert(summary_item_as_unused(&item) == NULL);
+
+    item.kind = SummaryItemHash;
+    assert(summary_item_as_unused(&item) == NULL);
+
+    item.kind = SummaryItemString;
+    assert(summary_item_as_unused(&item) == NULL);
+}
+
+void test_transaction_summary_reset() {
+    memset(&G_transaction_summary, 1, sizeof(TransactionSummary));
+    memset(G_transaction_summary_title, 1, TITLE_SIZE);
+    memset(G_transaction_summary_text, 1, TEXT_BUFFER_LENGTH);
+
+    transaction_summary_reset();
+
+    assert(strlen(G_transaction_summary_title) == 0);
+    assert(strlen(G_transaction_summary_text) == 0);
+
+    SummaryItem* item;
+
+    assert((item = transaction_summary_primary_item()) != NULL);
+    assert(item->kind == SummaryItemNone);
+
+    assert((item = transaction_summary_fee_payer_item()) != NULL);
+    assert(item->kind == SummaryItemNone);
+
+    assert((item = transaction_summary_nonce_account_item()) != NULL);
+    assert(item->kind == SummaryItemNone);
+
+    assert((item = transaction_summary_nonce_authority_item()) != NULL);
+    assert(item->kind == SummaryItemNone);
+
+    for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        assert((item = transaction_summary_general_item()) != NULL);
+        assert(item->kind == SummaryItemNone);
+    }
+}
+
+void test_transaction_summary_item_getters() {
+    SummaryItem* item;
+
+    assert((item = transaction_summary_primary_item()) != NULL);
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_primary_item() == NULL);
+
+    assert((item = transaction_summary_fee_payer_item()) != NULL);
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_fee_payer_item() == NULL);
+
+    assert((item = transaction_summary_nonce_account_item()) != NULL);
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_nonce_account_item() == NULL);
+
+    assert((item = transaction_summary_nonce_authority_item()) != NULL);
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_nonce_authority_item() == NULL);
+
+    for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        assert((item = transaction_summary_general_item()) != NULL);
+        summary_item_set_u64(item, "item", 42);
+    }
+    assert(transaction_summary_general_item() == NULL);
+}
+
+#define assert_transaction_summary_display(title, text)             \
+    do {                                                            \
+        assert_string_equal(G_transaction_summary_title, title);    \
+        assert_string_equal(G_transaction_summary_text, text);      \
+    } while (0)
+
+void test_transaction_summary_update_display_for_item() {
+    SummaryItem item;
+
+    item.kind = SummaryItemNone;
+    assert(transaction_summary_update_display_for_item(&item) == 1);
+
+    summary_item_set_amount(&item, "amount", 42);
+    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert_transaction_summary_display("amount", "0.000000042 SOL");
+
+    summary_item_set_u64(&item, "u64", 4242);
+    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert_transaction_summary_display("u64", "4242");
+
+    Pubkey pubkey;
+    memset(&pubkey, 0, sizeof(Pubkey));
+    summary_item_set_pubkey(&item, "pubkey", &pubkey);
+    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert_transaction_summary_display("pubkey", "1111111..1111111");
+
+    Hash hash;
+    memset(&hash, 0, sizeof(Hash));
+    summary_item_set_hash(&item, "hash", &hash);
+    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert_transaction_summary_display("hash", "11111111111111111111111111111111");
+
+    const char* string = "value";
+    summary_item_set_string(&item, "string", string);
+    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert_transaction_summary_display("string", "value");
+}
+
+#define display_item_test_helper(item, item_index)                      \
+    do {                                                                \
+        SummaryItem* si;                                                \
+        assert((si = transaction_summary_ ## item ## _item()) != NULL); \
+        summary_item_set_u64(si, #item, 42);                            \
+        assert(transaction_summary_display_item(item_index) == 0);      \
+        assert_transaction_summary_display(#item, "42");                \
+    } while (0)
+
+#define display_item_test_helper_general_item(general_index)                \
+    do {                                                                    \
+        SummaryItem* si;                                                    \
+        const char* title = "general_" #general_index;                      \
+        assert((si = transaction_summary_general_item()) != NULL);          \
+        summary_item_set_u64(si, title, 42);                                \
+        assert(transaction_summary_display_item(general_index + 1) == 0);   \
+        assert_transaction_summary_display(title, "42");                    \
+    } while (0)
+
+void test_transaction_summary_display_item() {
+    transaction_summary_reset();
+
+    display_item_test_helper(primary, 0);
+
+    for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        display_item_test_helper_general_item(i);
+    }
+
+    display_item_test_helper(nonce_account, 1 + NUM_GENERAL_ITEMS);
+    display_item_test_helper(nonce_authority, 1 + NUM_GENERAL_ITEMS + 1);
+    display_item_test_helper(fee_payer, 1 + NUM_GENERAL_ITEMS + 2);
+}
+
+#define zero_kinds_array(kinds) \
+    memset(kinds, 0, MAX_TRANSACTION_SUMMARY_ITEMS * sizeof(enum SummaryItemKind))
+
+#define assert_kinds_array(kinds, num_kinds)                            \
+    do {                                                                \
+        for (size_t k = 0; k < MAX_TRANSACTION_SUMMARY_ITEMS; k++) {    \
+            if (k < num_kinds) {                                        \
+                assert(kinds[k] == SummaryItemU64);                     \
+            } else {                                                    \
+                assert(kinds[k] == SummaryItemNone);                    \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+void test_transaction_summary_finalize() {
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    SummaryItem* item;
+
+    transaction_summary_reset();
+
+    // No items set fails
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 1);
+
+    // Only optional items set fails
+    size_t i;
+    for (i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        item = transaction_summary_general_item();
+        summary_item_set_u64(item, "item", 42);
+    }
+    item = transaction_summary_nonce_account_item();
+    summary_item_set_u64(item, "item", 42);
+    item = transaction_summary_nonce_authority_item();
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 1);
+
+    // No primary set fails
+    item = transaction_summary_fee_payer_item();
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 1);
+
+    // No fee-payer set fails
+    transaction_summary_reset();
+    item = transaction_summary_primary_item();
+    summary_item_set_u64(item, "item", 42);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 1);
+
+    // Minimum items set (primary + fee_payer) succeeds
+    item = transaction_summary_fee_payer_item();
+    summary_item_set_u64(item, "item", 42);
+    num_kinds = 0;
+    zero_kinds_array(kinds);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 2);
+    assert_kinds_array(kinds, num_kinds);
+
+    // Optionals still succeed and count
+    for (i = 0; i < NUM_GENERAL_ITEMS; i++) {
+        item = transaction_summary_general_item();
+        summary_item_set_u64(item, "item", 42);
+        num_kinds = 0;
+        zero_kinds_array(kinds);
+        assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+        assert(num_kinds == (2 + 1 + i));
+        assert_kinds_array(kinds, num_kinds);
+    }
+
+    item = transaction_summary_nonce_account_item();
+    summary_item_set_u64(item, "item", 42);
+    num_kinds = 0;
+    zero_kinds_array(kinds);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == (2 + NUM_GENERAL_ITEMS + 1));
+    assert_kinds_array(kinds, num_kinds);
+
+    item = transaction_summary_nonce_authority_item();
+    summary_item_set_u64(item, "item", 42);
+    num_kinds = 0;
+    zero_kinds_array(kinds);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == (2 + NUM_GENERAL_ITEMS + 2));
+    assert_kinds_array(kinds, num_kinds);
+}
+
+void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug() {
+    SummaryItem* item;
+    const char* primary_title = "Unrecognized";
+    const char* primary_text = "format";
+    const char* fee_payer_title = "Fee payer";
+    const char* fee_payer_text = "1111111..1111111";
+    Pubkey fee_payer = {{
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    }};
+    const char* message_hash_title = "Message hash";
+    const char* message_hash_text =
+        "22222222222222222222222222222222222222222222";
+    Hash message_hash = {{
+        0x0f, 0x1e, 0x6b, 0x14, 0x21, 0xc0, 0x4a, 0x07, 0x04, 0x31, 0x26, 0x5c,
+        0x19, 0xc5, 0xbb, 0xee, 0x19, 0x92, 0xba, 0xe8, 0xaf, 0xd1, 0xcd, 0x07,
+        0x8e, 0xf8, 0xaf, 0x70, 0x47, 0xdc, 0x11, 0xf7
+    }};
+
+    transaction_summary_reset();
+
+    item = transaction_summary_fee_payer_item();
+    summary_item_set_pubkey(item, fee_payer_title, &fee_payer);
+    item = transaction_summary_general_item();
+    summary_item_set_hash(item, message_hash_title, &message_hash);
+    item = transaction_summary_primary_item();
+    summary_item_set_string(item, primary_title, primary_text);
+
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds = 0;
+    zero_kinds_array(kinds);
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 3);
+
+    assert(transaction_summary_display_item(0) == 0);
+    assert_transaction_summary_display(primary_title, primary_text);
+    assert(transaction_summary_display_item(1) == 0);
+    assert_transaction_summary_display(message_hash_title, message_hash_text);
+    assert(transaction_summary_display_item(2) == 0);
+    assert_transaction_summary_display(fee_payer_title, fee_payer_text);
+    assert(transaction_summary_display_item(1) == 0);
+    assert_transaction_summary_display(message_hash_title, message_hash_text);
+    assert(transaction_summary_display_item(0) == 0);
+    assert_transaction_summary_display(primary_title, primary_text);
+}
+
+int main() {
+    test_summary_item_setters();
+    test_summary_item_as_unused();
+
+    test_transaction_summary_reset();
+    test_transaction_summary_item_getters();
+    test_transaction_summary_update_display_for_item();
+    test_transaction_summary_display_item();
+    test_transaction_summary_finalize();
+
+    test_repro_unrecognized_format_reverse_nav_hash_corruption_bug();
+
+    printf("passed\n");
+    return 0;
+}

--- a/libsol/util.h
+++ b/libsol/util.h
@@ -2,3 +2,5 @@
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 #define BAIL_IF(x) {int err = x; if (err) return err;}
+
+#define assert_string_equal(actual, expected) assert(strcmp(actual, expected) == 0)

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -113,10 +113,9 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
         sendResponse(0, false);
     }
 
-    SummaryItem* item;
     transaction_summary_reset();
     if (process_message_body(parser.buffer, parser.buffer_length, &header)) {
-        item = transaction_summary_primary_item();
+        SummaryItem* item = transaction_summary_primary_item();
         summary_item_set_string(item, "Unrecognized", "format");
 
         cx_hash_sha256(dataBuffer, dataLength, (uint8_t*) &UnrecognizedMessageHash, HASH_LENGTH);
@@ -127,10 +126,7 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 
     // Set fee-payer if it hasn't already been resolved by
     // the transaction printer
-    item = transaction_summary_fee_payer_item();
-    if (item != NULL) {
-        summary_item_set_pubkey(item, "Fee payer", &header.pubkeys[0]);
-    }
+    transaction_summary_set_fee_payer_pubkey(&header.pubkeys[0]);
 
     enum SummaryItemKind summary_step_kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
     size_t num_summary_steps = 0;

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -6,6 +6,7 @@
 #include "sol/parser.h"
 #include "sol/printer.h"
 #include "sol/message.h"
+#include "sol/transaction_summary.h"
 
 static field_t G_fields[6];
 
@@ -120,6 +121,31 @@ UX_FLOW(ux_6_fields,
   &ux_reject_step
 );
 
+UX_STEP_NOCB_INIT(
+    ux_summary_step,
+    paging,
+    {
+        size_t step_index = G_ux.flow_stack[stack_slot].index;
+        if (transaction_summary_display_item(step_index)) {
+            THROW(0x6f01);
+        }
+    },
+    {
+        .title = G_transaction_summary_title,
+        .text = G_transaction_summary_text,
+    }
+);
+
+#define MAX_FLOW_STEPS ( \
+    MAX_TRANSACTION_SUMMARY_ITEMS   \
+    + 1     /* approve */           \
+    + 1     /* reject */            \
+    + 1     /* FLOW_END_STEP */     \
+)
+ux_flow_step_t const * flow_steps[MAX_FLOW_STEPS];
+
+Hash UnrecognizedMessageHash;
+
 void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dataLength, volatile unsigned int *flags, volatile unsigned int *tx) {
     if ((p2 & P2_EXTEND) == 0) {
         MEMCLEAR(G_derivationPath);
@@ -166,31 +192,54 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
     print_summary(pubkeyBuffer, G_fields[3].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
 
     size_t fieldsUsed = 0;
+    SummaryItem* item;
+    transaction_summary_reset();
     if (process_message_body(parser.buffer, parser.buffer_length, &header, G_fields, &fieldsUsed)) {
-        strcpy(G_fields[0].title, "Unrecognized");
-        strcpy(G_fields[0].text, "format");
+        item = transaction_summary_primary_item();
+        summary_item_set_string(item, "Unrecognized", "format");
 
-        uint8_t messageHashBytes[HASH_LENGTH];
-        cx_hash_sha256(dataBuffer, dataLength, messageHashBytes, HASH_LENGTH);
+        cx_hash_sha256(dataBuffer, dataLength, (uint8_t*) &UnrecognizedMessageHash, HASH_LENGTH);
 
-        strcpy(G_fields[1].title, "Message Hash");
-        encode_base58(messageHashBytes, HASH_LENGTH, G_fields[1].text, BASE58_PUBKEY_LENGTH);
-        fieldsUsed = 3;
+        item = transaction_summary_general_item();
+        summary_item_set_hash(item, "Message Hash", &UnrecognizedMessageHash);
     }
 
-    switch (fieldsUsed) {
-    case 3:
-        ux_flow_init(0, ux_3_fields, NULL);
-        break;
-    case 4:
-        ux_flow_init(0, ux_4_fields, NULL);
-        break;
-    case 6:
-        ux_flow_init(0, ux_6_fields, NULL);
-        break;
-    default:
-        THROW(0x6f00);
-        return;
+    // Set fee-payer if it hasn't already been resolved by
+    // the transaction printer
+    item = transaction_summary_fee_payer_item();
+    if (item != NULL) {
+        summary_item_set_pubkey(item, "Fee payer", &header.pubkeys[0]);
+    }
+
+    enum SummaryItemKind summary_step_kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_summary_steps = 0;
+    if (transaction_summary_finalize(summary_step_kinds, &num_summary_steps) == 0) {
+        size_t num_flow_steps = 0;
+
+        for (size_t i = 0; i < num_summary_steps; i++) {
+            flow_steps[num_flow_steps++] = &ux_summary_step;
+        }
+
+        flow_steps[num_flow_steps++] = &ux_approve_step;
+        flow_steps[num_flow_steps++] = &ux_reject_step;
+        flow_steps[num_flow_steps++] = FLOW_END_STEP;
+
+        ux_flow_init(0, flow_steps, NULL);
+    } else {
+        switch (fieldsUsed) {
+        case 3:
+            ux_flow_init(0, ux_3_fields, NULL);
+            break;
+        case 4:
+            ux_flow_init(0, ux_4_fields, NULL);
+            break;
+        case 6:
+            ux_flow_init(0, ux_6_fields, NULL);
+            break;
+        default:
+            THROW(0x6f00);
+            return;
+        }
     }
 
     *flags |= IO_ASYNCH_REPLY;

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -8,8 +8,6 @@
 #include "sol/message.h"
 #include "sol/transaction_summary.h"
 
-static field_t G_fields[6];
-
 static uint8_t G_message[MAX_MESSAGE_LENGTH];
 static int G_messageLength;
 static uint32_t G_derivationPath[BIP32_PATH];
@@ -34,48 +32,6 @@ static uint8_t set_result_sign_message() {
 
 //////////////////////////////////////////////////////////////////////
 
-UX_STEP_NOCB(
-    ux_instruction_step,
-    bnnn_paging,
-    {
-      .title = G_fields[0].title,
-      .text = G_fields[0].text,
-    });
-UX_STEP_NOCB(
-    ux_sender_step,
-    bnnn_paging,
-    {
-      .title = G_fields[1].title,
-      .text = G_fields[1].text,
-    });
-UX_STEP_NOCB(
-    ux_recipient_step,
-    bnnn_paging,
-    {
-      .title = G_fields[2].title,
-      .text = G_fields[2].text,
-    });
-UX_STEP_NOCB(
-    ux_fee_payer_step,
-    bnnn_paging,
-    {
-      .title = "Fee paid by",
-      .text = G_fields[3].text,
-    });
-UX_STEP_NOCB(
-    ux_nonce_account_step,
-    bnnn_paging,
-    {
-      .title = "Nonce account",
-      .text = G_fields[4].text,
-    });
-UX_STEP_NOCB(
-    ux_nonce_authority_step,
-    bnnn_paging,
-    {
-      .title = "Nonce authority",
-      .text = G_fields[5].text,
-    });
 UX_STEP_VALID(
     ux_approve_step,
     pb,
@@ -92,35 +48,6 @@ UX_STEP_VALID(
       &C_icon_crossmark,
       "Reject",
     });
-
-UX_FLOW(ux_3_fields,
-  &ux_instruction_step,
-  &ux_sender_step,
-  &ux_fee_payer_step,
-  &ux_approve_step,
-  &ux_reject_step
-);
-
-UX_FLOW(ux_4_fields,
-  &ux_instruction_step,
-  &ux_sender_step,
-  &ux_recipient_step,
-  &ux_fee_payer_step,
-  &ux_approve_step,
-  &ux_reject_step
-);
-
-UX_FLOW(ux_6_fields,
-  &ux_instruction_step,
-  &ux_sender_step,
-  &ux_recipient_step,
-  &ux_fee_payer_step,
-  &ux_nonce_account_step,
-  &ux_nonce_authority_step,
-  &ux_approve_step,
-  &ux_reject_step
-);
-
 UX_STEP_NOCB_INIT(
     ux_summary_step,
     paging,
@@ -186,15 +113,9 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
         sendResponse(0, false);
     }
 
-    // Set fee payer text
-    char pubkeyBuffer[BASE58_PUBKEY_LENGTH];
-    encode_base58(&header.pubkeys[0], PUBKEY_LENGTH, pubkeyBuffer, BASE58_PUBKEY_LENGTH);
-    print_summary(pubkeyBuffer, G_fields[3].text, BASE58_PUBKEY_SHORT, SUMMARY_LENGTH, SUMMARY_LENGTH);
-
-    size_t fieldsUsed = 0;
     SummaryItem* item;
     transaction_summary_reset();
-    if (process_message_body(parser.buffer, parser.buffer_length, &header, G_fields, &fieldsUsed)) {
+    if (process_message_body(parser.buffer, parser.buffer_length, &header)) {
         item = transaction_summary_primary_item();
         summary_item_set_string(item, "Unrecognized", "format");
 
@@ -226,20 +147,8 @@ void handleSignMessage(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t dat
 
         ux_flow_init(0, flow_steps, NULL);
     } else {
-        switch (fieldsUsed) {
-        case 3:
-            ux_flow_init(0, ux_3_fields, NULL);
-            break;
-        case 4:
-            ux_flow_init(0, ux_4_fields, NULL);
-            break;
-        case 6:
-            ux_flow_init(0, ux_6_fields, NULL);
-            break;
-        default:
-            THROW(0x6f00);
-            return;
-        }
+        THROW(0x6f00);
+        return;
     }
 
     *flags |= IO_ASYNCH_REPLY;


### PR DESCRIPTION
#### Problem

Existing display facilities make excessive use of memory, hampering the addition of new new display fields

#### Changes

This change set is 1:1, visually, with master.  We trade ~128b of .text  for ~220b of .bss for the present display field usage.  In the worst case field usage (create-stake-account --seed ...), the .bss savings goes up to ~700b without change in .text usage.

1. Adds a new manager for display fields which leverages the fact that the message buffer is parsed in a zero-copy fashion to save ~75% memory per field
1. Reworks the usage of BOLOS lib_ux to avoid unnecessary data duplication
    - Single `UX_STEP_NOCB_INIT` for all summary items using a `preinit` callback
    - Single `UX_FLOW` of worst-case size, which is dynamically setup based on usage
1. Improved ergonomics