### PR TITLE
Restore message buffer to full-shred size

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -11,7 +11,12 @@
 #define P2_EXTEND 0x01
 #define P2_MORE 0x02
 
-#define MAX_MESSAGE_LENGTH 1000
+#define ROUND_TO_NEXT(x, next) (((x) == 0) ? 0 : ((((x - 1) / (next)) + 1) * (next)))
+
+/* See constant by same name in sdk/src/packet.rs */
+#define PACKET_DATA_SIZE (1280 - 40 - 8)
+
+#define MAX_MESSAGE_LENGTH ROUND_TO_NEXT(PACKET_DATA_SIZE, USB_SEGMENT_SIZE)
 #define SIGNATURE_LENGTH 64
 #define HASH_LENGTH 32
 #define PUBKEY_LENGTH HASH_LENGTH


### PR DESCRIPTION
#### Problem

After #65, the app can no longer sign a protocol maximum-sized transaction.  As of #78, this is no longer necessary

#### Changes

Declare `PACKET_DATA_SIZE` as per core sources (and link to its origin)
Declare macro for rounding up to next multiple
Declare `MAX_MESSAGE_LENGTH` to be the next multiple of the USB MTU that holds `PACKET_DATA_SIZE`