### PR TITLE
Add more primitive parsers

### DIFF
--- a/libsol/include/sol/parser.h
+++ b/libsol/include/sol/parser.h
@@ -12,6 +12,13 @@ typedef struct Parser {
     size_t buffer_length;
 } Parser;
 
+typedef struct SizedString {
+    uint64_t length;
+    // TODO: This can technically contain UTF-8. Need to figure out a
+    // nano-s-compatible strategy for dealing with non-ASCII chars...
+    const char* string;
+} SizedString;
+
 typedef struct Pubkey {
     uint8_t data[PUBKEY_SIZE];
 } Pubkey;
@@ -51,7 +58,13 @@ int parse_u32(Parser* parser, uint32_t* value);
 
 int parse_u64(Parser* parser, uint64_t* value);
 
+int parse_i64(Parser* parser, int64_t* value);
+
 int parse_length(Parser* parser, size_t* value);
+
+int parse_sized_string(Parser* parser, SizedString* string);
+
+int parse_pubkey(Parser* parser, Pubkey** pubkey);
 
 int parse_pubkeys_header(Parser* parser, PubkeysHeader* header);
 

--- a/libsol/parser.c
+++ b/libsol/parser.c
@@ -42,6 +42,11 @@ int parse_u64(Parser* parser, uint64_t* value) {
     return 0;
 }
 
+int parse_i64(Parser* parser, int64_t* value) {
+    uint64_t* as_u64 = (uint64_t*) value;
+    return parse_u64(parser, as_u64);
+}
+
 int parse_length(Parser* parser, size_t* value) {
     uint8_t value_u8;
     BAIL_IF(parse_u8(parser, &value_u8));
@@ -55,6 +60,23 @@ int parse_length(Parser* parser, size_t* value) {
             *value = ((value_u8 & 0x7f) << 14) | *value;
 	}
     }
+    return 0;
+}
+
+int parse_sized_string(Parser* parser, SizedString* string) {
+    BAIL_IF(parse_u64(parser, &string->length));
+    BAIL_IF(string->length > SIZE_MAX);
+    size_t len = (size_t) string->length;
+    BAIL_IF(check_buffer_length(parser, len));
+    string->string = (char*)parser->buffer;
+    advance(parser, len);
+    return 0;
+}
+
+int parse_pubkey(Parser* parser, Pubkey** pubkey) {
+    BAIL_IF(check_buffer_length(parser, PUBKEY_SIZE));
+    *pubkey = (Pubkey*) parser->buffer;
+    advance(parser, PUBKEY_SIZE);
     return 0;
 }
 


### PR DESCRIPTION
#### Problem

No mechanism to parse an `i64`, a single `Pubkey` or a sized, non-null-terminated string (ala Rust's `String`)

#### Changes

Add parsers
Test parsers