### PR TITLE
Prefix instruction enum variants to avoid name collisions

### DIFF
--- a/libsol/instruction_test.c
+++ b/libsol/instruction_test.c
@@ -60,11 +60,11 @@ void test_instruction_validate_bad_last_account_index_fail() {
 }
 
 void test_static_brief_initializer_macros() {
-    InstructionBrief system_test = SYSTEM_IX_BRIEF(Transfer);
-    InstructionBrief system_expect = { ProgramIdSystem, .system = Transfer };
+    InstructionBrief system_test = SYSTEM_IX_BRIEF(SystemTransfer);
+    InstructionBrief system_expect = { ProgramIdSystem, .system = SystemTransfer };
     assert(memcmp(&system_test, &system_expect, sizeof(InstructionBrief)) == 0);
-    InstructionBrief stake_test = STAKE_IX_BRIEF(DelegateStake);
-    InstructionBrief stake_expect = { ProgramIdStake, .stake = DelegateStake };
+    InstructionBrief stake_test = STAKE_IX_BRIEF(StakeDelegate);
+    InstructionBrief stake_expect = { ProgramIdStake, .stake = StakeDelegate };
     assert(memcmp(&stake_test, &stake_expect, sizeof(InstructionBrief)) == 0);
 }
 
@@ -72,13 +72,13 @@ void test_instruction_info_matches_brief() {
     InstructionInfo info = {
         .kind = ProgramIdSystem,
         .system = {
-            .kind = Transfer,
+            .kind = SystemTransfer,
             .transfer = { NULL, NULL, 0 },
         },
     };
-    InstructionBrief brief_pass = SYSTEM_IX_BRIEF(Transfer);
+    InstructionBrief brief_pass = SYSTEM_IX_BRIEF(SystemTransfer);
     assert(instruction_info_matches_brief(&info, &brief_pass));
-    InstructionBrief brief_fail = SYSTEM_IX_BRIEF(AdvanceNonceAccount);
+    InstructionBrief brief_fail = SYSTEM_IX_BRIEF(SystemAdvanceNonceAccount);
     assert(!instruction_info_matches_brief(&info, &brief_fail));
 }
 
@@ -87,25 +87,25 @@ void test_instruction_infos_match_briefs() {
         {
             .kind = ProgramIdSystem,
             .system = {
-                .kind = Transfer,
+                .kind = SystemTransfer,
                 .transfer = { NULL, NULL, 0 },
             },
         },
         {
             .kind = ProgramIdStake,
             .stake = {
-                .kind = DelegateStake,
+                .kind = StakeDelegate,
                 .delegate_stake = { NULL, NULL, NULL },
             },
         }
     };
     InstructionBrief briefs[] = {
-        SYSTEM_IX_BRIEF(Transfer),
-        STAKE_IX_BRIEF(DelegateStake),
+        SYSTEM_IX_BRIEF(SystemTransfer),
+        STAKE_IX_BRIEF(StakeDelegate),
     };
     InstructionBrief bad_briefs[] = {
-        SYSTEM_IX_BRIEF(Transfer),
-        STAKE_IX_BRIEF(Split),
+        SYSTEM_IX_BRIEF(SystemTransfer),
+        STAKE_IX_BRIEF(StakeSplit),
     };
     size_t infos_len = ARRAY_LEN(infos);
     assert(infos_len == ARRAY_LEN(briefs));

--- a/libsol/message.c
+++ b/libsol/message.c
@@ -55,7 +55,7 @@ int process_message_body(uint8_t* message_body, int message_body_length, Message
     size_t operative_ix = 0;
     InstructionInfo* info = &instruction_info[operative_ix];
     if (instruction_count > 1) {
-        InstructionBrief nonce_brief = SYSTEM_IX_BRIEF(AdvanceNonceAccount);
+        InstructionBrief nonce_brief = SYSTEM_IX_BRIEF(SystemAdvanceNonceAccount);
         if (instruction_info_matches_brief(info, &nonce_brief)) {
             print_system_nonced_transaction_sentinel(&info->system, header);
             operative_ix++;

--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -16,22 +16,22 @@ static int parse_stake_instruction_kind(Parser* parser, enum StakeInstructionKin
     uint32_t maybe_kind;
     BAIL_IF(parse_u32(parser, &maybe_kind));
     switch (maybe_kind) {
-        case Initialize:
-        case Authorize:
-        case DelegateStake:
-        case Split:
-        case Withdraw:
-        case Deactivate:
-        case SetLockup:
+        case StakeInitialize:
+        case StakeAuthorize:
+        case StakeDelegate:
+        case StakeSplit:
+        case StakeWithdraw:
+        case StakeDeactivate:
+        case StakeSetLockup:
             *kind = (enum StakeInstructionKind) maybe_kind;
             return 0;
     }
     return 1;
 }
 
-// Returns 0 and populates DelegateStakeInfo if provided a MessageHeader and a delegate
+// Returns 0 and populates StakeDelegateInfo if provided a MessageHeader and a delegate
 // instruction, otherwise non-zero.
-static int parse_delegate_stake_instruction(Instruction* instruction, Pubkey* pubkeys, size_t pubkeys_length, DelegateStakeInfo* info) {
+static int parse_delegate_stake_instruction(Instruction* instruction, Pubkey* pubkeys, size_t pubkeys_length, StakeDelegateInfo* info) {
     BAIL_IF(instruction->accounts_length < 6);
     uint8_t accounts_index = 0;
     uint8_t pubkeys_index = instruction->accounts[accounts_index++];
@@ -70,21 +70,21 @@ int parse_stake_instructions(Instruction* instruction, MessageHeader* header, St
     BAIL_IF(parse_stake_instruction_kind(&parser, &info->kind));
 
     switch (info->kind) {
-        case DelegateStake:
+        case StakeDelegate:
             return parse_delegate_stake_instruction(instruction, header->pubkeys, header->pubkeys_header.pubkeys_length, &info->delegate_stake);
-        case Initialize:
-        case Authorize:
-        case Split:
-        case Withdraw:
-        case Deactivate:
-        case SetLockup:
+        case StakeInitialize:
+        case StakeAuthorize:
+        case StakeSplit:
+        case StakeWithdraw:
+        case StakeDeactivate:
+        case StakeSetLockup:
             break;
     }
 
     return 1;
 }
 
-static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* header) {
+static int print_delegate_stake_info(StakeDelegateInfo* info, MessageHeader* header) {
     SummaryItem* item;
 
     item = transaction_summary_primary_item();
@@ -106,14 +106,14 @@ static int print_delegate_stake_info(DelegateStakeInfo* info, MessageHeader* hea
 
 int print_stake_info(StakeInfo* info, MessageHeader* header) {
     switch (info->kind) {
-        case DelegateStake:
+        case StakeDelegate:
             return print_delegate_stake_info(&info->delegate_stake, header);
-        case Initialize:
-        case Authorize:
-        case Split:
-        case Withdraw:
-        case Deactivate:
-        case SetLockup:
+        case StakeInitialize:
+        case StakeAuthorize:
+        case StakeSplit:
+        case StakeWithdraw:
+        case StakeDeactivate:
+        case StakeSetLockup:
             break;
     }
 

--- a/libsol/stake_instruction.h
+++ b/libsol/stake_instruction.h
@@ -6,25 +6,25 @@
 extern const Pubkey stake_program_id;
 
 enum StakeInstructionKind {
-    Initialize,
-    Authorize,
-    DelegateStake,
-    Split,
-    Withdraw,
-    Deactivate,
-    SetLockup,
+    StakeInitialize,
+    StakeAuthorize,
+    StakeDelegate,
+    StakeSplit,
+    StakeWithdraw,
+    StakeDeactivate,
+    StakeSetLockup,
 };
 
-typedef struct DelegateStakeInfo {
+typedef struct StakeDelegateInfo {
     Pubkey* stake_pubkey;
     Pubkey* vote_pubkey;
     Pubkey* authorized_pubkey;
-} DelegateStakeInfo;
+} StakeDelegateInfo;
 
 typedef struct StakeInfo {
     enum StakeInstructionKind kind;
     union {
-        DelegateStakeInfo delegate_stake;
+        StakeDelegateInfo delegate_stake;
     };
 } StakeInfo;
 

--- a/libsol/stake_instruction_test.c
+++ b/libsol/stake_instruction_test.c
@@ -23,43 +23,43 @@ void test_parse_stake_instruction_kind() {
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Initialize);
+    assert(kind == StakeInitialize);
 
     buf[0] = 1;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Authorize);
+    assert(kind == StakeAuthorize);
 
     buf[0] = 2;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == DelegateStake);
+    assert(kind == StakeDelegate);
 
     buf[0] = 3;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Split);
+    assert(kind == StakeSplit);
 
     buf[0] = 4;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Withdraw);
+    assert(kind == StakeWithdraw);
 
     buf[0] = 5;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Deactivate);
+    assert(kind == StakeDeactivate);
 
     buf[0] = 6;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_stake_instruction_kind(&parser, &kind) == 0);
-    assert(kind == SetLockup);
+    assert(kind == StakeSetLockup);
 
     // Fail the first unused enum value to be sure this test gets updated
     buf[0] = 7;

--- a/libsol/system_instruction.c
+++ b/libsol/system_instruction.c
@@ -13,17 +13,17 @@ static int parse_system_instruction_kind(Parser* parser, enum SystemInstructionK
     uint32_t maybe_kind;
     BAIL_IF(parse_u32(parser, &maybe_kind));
     switch (maybe_kind) {
-        case CreateAccount:
-        case Assign:
-        case Transfer:
-        case CreateAccountWithSeed:
-        case AdvanceNonceAccount:
-        case WithdrawNonceAccount:
-        case InitializeNonceAccount:
-        case AuthorizeNonceAccount:
-        case Allocate:
-        case AllocateWithSeed:
-        case AssignWithSeed:
+        case SystemCreateAccount:
+        case SystemAssign:
+        case SystemTransfer:
+        case SystemCreateAccountWithSeed:
+        case SystemAdvanceNonceAccount:
+        case SystemWithdrawNonceAccount:
+        case SystemInitializeNonceAccount:
+        case SystemAuthorizeNonceAccount:
+        case SystemAllocate:
+        case SystemAllocateWithSeed:
+        case SystemAssignWithSeed:
             *kind = (enum SystemInstructionKind) maybe_kind;
             return 0;
     }
@@ -72,24 +72,24 @@ int parse_system_instructions(Instruction* instruction, MessageHeader* header, S
     BAIL_IF(parse_system_instruction_kind(&parser, &info->kind));
 
     switch (info->kind) {
-        case Transfer:
+        case SystemTransfer:
             return parse_system_transfer_instruction(&parser, instruction, header->pubkeys, header->pubkeys_header.pubkeys_length, &info->transfer);
-        case AdvanceNonceAccount:
+        case SystemAdvanceNonceAccount:
             return parse_system_advance_nonce_account_instruction(
                 &parser,
                 instruction,
                 header,
                 &info->advance_nonce
             );
-        case CreateAccount:
-        case Assign:
-        case CreateAccountWithSeed:
-        case WithdrawNonceAccount:
-        case InitializeNonceAccount:
-        case AuthorizeNonceAccount:
-        case Allocate:
-        case AllocateWithSeed:
-        case AssignWithSeed:
+        case SystemCreateAccount:
+        case SystemAssign:
+        case SystemCreateAccountWithSeed:
+        case SystemWithdrawNonceAccount:
+        case SystemInitializeNonceAccount:
+        case SystemAuthorizeNonceAccount:
+        case SystemAllocate:
+        case SystemAllocateWithSeed:
+        case SystemAssignWithSeed:
             break;
     }
 
@@ -137,19 +137,19 @@ static int print_system_advance_nonce_account(SystemAdvanceNonceInfo* info, Mess
 
 int print_system_info(SystemInfo* info, MessageHeader* header) {
     switch (info->kind) {
-        case Transfer:
+        case SystemTransfer:
             return print_system_transfer_info(&info->transfer, header);
-        case AdvanceNonceAccount:
+        case SystemAdvanceNonceAccount:
             return print_system_advance_nonce_account(&info->advance_nonce, header);
-        case CreateAccount:
-        case Assign:
-        case CreateAccountWithSeed:
-        case WithdrawNonceAccount:
-        case InitializeNonceAccount:
-        case AuthorizeNonceAccount:
-        case Allocate:
-        case AllocateWithSeed:
-        case AssignWithSeed:
+        case SystemCreateAccount:
+        case SystemAssign:
+        case SystemCreateAccountWithSeed:
+        case SystemWithdrawNonceAccount:
+        case SystemInitializeNonceAccount:
+        case SystemAuthorizeNonceAccount:
+        case SystemAllocate:
+        case SystemAllocateWithSeed:
+        case SystemAssignWithSeed:
             break;
     }
 

--- a/libsol/system_instruction.h
+++ b/libsol/system_instruction.h
@@ -5,17 +5,17 @@
 extern const Pubkey system_program_id;
 
 enum SystemInstructionKind {
-    CreateAccount,
-    Assign,
-    Transfer,
-    CreateAccountWithSeed,
-    AdvanceNonceAccount,
-    WithdrawNonceAccount,
-    InitializeNonceAccount,
-    AuthorizeNonceAccount,
-    Allocate,
-    AllocateWithSeed,
-    AssignWithSeed
+    SystemCreateAccount,
+    SystemAssign,
+    SystemTransfer,
+    SystemCreateAccountWithSeed,
+    SystemAdvanceNonceAccount,
+    SystemWithdrawNonceAccount,
+    SystemInitializeNonceAccount,
+    SystemAuthorizeNonceAccount,
+    SystemAllocate,
+    SystemAllocateWithSeed,
+    SystemAssignWithSeed
 };
 
 typedef struct SystemTransferInfo {

--- a/libsol/system_instruction_test.c
+++ b/libsol/system_instruction_test.c
@@ -68,7 +68,7 @@ void test_parse_system_advance_nonce_account_instruction() {
     enum SystemInstructionKind kind;
     Parser instruction_parser = { instruction.data, instruction.data_length };
     assert(parse_system_instruction_kind(&instruction_parser, &kind) == 0);
-    assert(kind == AdvanceNonceAccount);
+    assert(kind == SystemAdvanceNonceAccount);
 
     SystemAdvanceNonceInfo info;
     assert(parse_system_advance_nonce_account_instruction(&instruction_parser, &instruction, &header, &info) == 0);
@@ -130,67 +130,67 @@ void test_parse_system_instruction_kind() {
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == CreateAccount);
+    assert(kind == SystemCreateAccount);
 
     buf[0] = 1;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Assign);
+    assert(kind == SystemAssign);
 
     buf[0] = 2;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Transfer);
+    assert(kind == SystemTransfer);
 
     buf[0] = 3;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == CreateAccountWithSeed);
+    assert(kind == SystemCreateAccountWithSeed);
 
     buf[0] = 4;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == AdvanceNonceAccount);
+    assert(kind == SystemAdvanceNonceAccount);
 
     buf[0] = 5;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == WithdrawNonceAccount);
+    assert(kind == SystemWithdrawNonceAccount);
 
     buf[0] = 6;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == InitializeNonceAccount);
+    assert(kind == SystemInitializeNonceAccount);
 
     buf[0] = 7;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == AuthorizeNonceAccount);
+    assert(kind == SystemAuthorizeNonceAccount);
 
     buf[0] = 8;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == Allocate);
+    assert(kind == SystemAllocate);
 
     buf[0] = 9;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == AllocateWithSeed);
+    assert(kind == SystemAllocateWithSeed);
 
     buf[0] = 10;
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_system_instruction_kind(&parser, &kind) == 0);
-    assert(kind == AssignWithSeed);
+    assert(kind == SystemAssignWithSeed);
 
     // Fail the first unused enum value to be sure this test gets updated
     buf[0] = 11;


### PR DESCRIPTION
#### Problem

Instruction enum variant names are the same as Rust where we have namespaces, in C where we don't.  Namespace collisions are inevitable

#### Changes

Prefix instruction names with their corresponding program name