### PR TITLE
Support `create-stake-account` TX

### DIFF
--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -182,6 +182,52 @@ void test_process_message_body_nonced_stake_create_with_seed() {
     }
 }
 
+void test_process_message_body_create_stake_account() {
+    uint8_t message[] = {
+        2, 0, 3,
+        5,
+            18, 67, 85, 168, 124, 173, 88, 142, 77, 171, 80, 178, 8, 218, 230, 68, 85, 231, 39, 54, 184, 42, 162, 85, 172, 139, 54, 173, 194, 7, 64, 250,
+            112, 173, 25, 161, 89, 143, 220, 223, 128, 33, 149, 41, 12, 152, 202, 202, 203, 163, 182, 246, 158, 15, 22, 77, 171, 71, 63, 249, 10, 117, 172, 52,
+            6, 167, 213, 23, 25, 44, 92, 81, 33, 140, 201, 76, 61, 74, 241, 127, 88, 218, 238, 8, 155, 161, 253, 68, 227, 219, 217, 138, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            6, 161, 216, 23, 145, 55, 84, 42, 152, 52, 55, 189, 254, 42, 122, 178, 85, 127, 83, 92, 138, 120, 114, 43, 104, 164, 157, 192, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        2,
+            3,
+            2,
+                0, 1,
+            52,
+                0, 0, 0, 0,
+                42, 0, 0, 0, 0, 0, 0, 0,
+                200, 0, 0, 0, 0, 0, 0, 0,
+                6, 161, 216, 23, 145, 55, 84, 42, 152, 52, 55, 189, 254, 42, 122, 178, 85, 127, 83, 92, 138, 120, 114, 43, 104, 164, 157, 192, 0, 0, 0, 0,
+            4,
+            2,
+                1, 2,
+            116,
+                0, 0, 0, 0,
+                3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    MessageHeader header;
+    Parser parser = { message, sizeof(message) };
+    assert(parse_message_header(&parser, &header) == 0);
+    transaction_summary_reset();
+    assert(process_message_body(parser.buffer, parser.buffer_length, &header) == 0);
+    transaction_summary_set_fee_payer_pubkey(&header.pubkeys[0]);
+
+    enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
+    size_t num_kinds;
+    assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
+    assert(num_kinds == 8);
+    for (size_t i = 0; i < num_kinds; i++) {
+        assert(transaction_summary_display_item(i) == 0);
+    }
+}
+
 int main() {
     test_process_message_body_ok();
     test_process_message_body_too_few_ix_fail();
@@ -193,6 +239,7 @@ int main() {
     test_process_message_body_ix_with_unknown_program_id_fail();
     test_process_message_body_xfer_w_nonce_ok();
     test_process_message_body_nonced_stake_create_with_seed();
+    test_process_message_body_create_stake_account();
 
     printf("passed\n");
     return 0;

--- a/libsol/system_instruction.h
+++ b/libsol/system_instruction.h
@@ -18,6 +18,12 @@ enum SystemInstructionKind {
     SystemAssignWithSeed
 };
 
+typedef struct SystemCreateAccountInfo {
+    const Pubkey* from;
+    const Pubkey* to;
+    uint64_t lamports;
+} SystemCreateAccountInfo;
+
 typedef struct SystemCreateAccountWithSeedInfo {
     const Pubkey* from;
     const Pubkey* to;
@@ -41,6 +47,7 @@ typedef struct SystemInfo {
     enum SystemInstructionKind kind;
     union {
         SystemTransferInfo transfer;
+        SystemCreateAccountInfo create_account;
         SystemCreateAccountWithSeedInfo create_account_with_seed;
         SystemAdvanceNonceInfo advance_nonce;
     };
@@ -49,6 +56,11 @@ typedef struct SystemInfo {
 int parse_system_instructions(const Instruction* instruction, const MessageHeader* header, SystemInfo* info);
 int print_system_info(const SystemInfo* info, const MessageHeader* header);
 int print_system_nonced_transaction_sentinel(const SystemInfo* info, const MessageHeader* header);
+int print_system_create_account_info(
+    const char* primary_title,
+    const SystemCreateAccountInfo* info,
+    const MessageHeader* header
+);
 int print_system_create_account_with_seed_info(
     const char* primary_title,
     const SystemCreateAccountWithSeedInfo* info,


### PR DESCRIPTION
Adds support for `solana create-stake-account` w/o seed TX