### PR TITLE
Enum parse tests

### DIFF
--- a/libsol/stake_instruction_test.c
+++ b/libsol/stake_instruction_test.c
@@ -149,10 +149,40 @@ void test_parse_stake_instruction_kind() {
     assert(parse_stake_instruction_kind(&parser, &kind) == 1);
 }
 
+void test_parse_stake_authorize_enum() {
+    enum StakeAuthorize authorize;
+    uint8_t buf[] = {0, 0, 0, 0};
+    Parser parser = {buf, ARRAY_LEN(buf)};
+    assert(parse_stake_authorize(&parser, &authorize) == 0);
+    assert(authorize == StakeAuthorizeStaker);
+
+    buf[0] = 1;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_authorize(&parser, &authorize) == 0);
+    assert(authorize == StakeAuthorizeWithdrawer);
+
+    // Fail the first unused enum value to be sure this test gets updated
+    buf[0] = 2;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_authorize(&parser, &authorize) == 1);
+
+    // Should always fail
+    buf[0] = 255;
+    buf[1] = 255;
+    buf[2] = 255;
+    buf[3] = 255;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_stake_authorize(&parser, &authorize) == 1);
+}
+
 int main() {
     test_parse_delegate_stake_instructions();
     test_parse_stake_initialize_instruction();
     test_parse_stake_instruction_kind();
+    test_parse_stake_authorize_enum();
 
     printf("passed\n");
     return 0;

--- a/libsol/vote_instruction_test.c
+++ b/libsol/vote_instruction_test.c
@@ -1,0 +1,87 @@
+#include "vote_instruction.c"
+#include <assert.h>
+#include <stdio.h>
+
+void test_parse_vote_instruction_kind() {
+    enum VoteInstructionKind kind;
+    uint8_t buf[] = {0, 0, 0, 0};
+    Parser parser = {buf, ARRAY_LEN(buf)};
+    assert(parse_vote_instruction_kind(&parser, &kind) == 0);
+    assert(kind == VoteInitialize);
+
+    buf[0] = 1;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 0);
+    assert(kind == VoteAuthorize);
+
+    buf[0] = 2;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 0);
+    assert(kind == VoteVote);
+
+    buf[0] = 3;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 0);
+    assert(kind == VoteWithdraw);
+
+    buf[0] = 4;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 0);
+    assert(kind == VoteUpdateNode);
+
+    // Fail the first unused enum value to be sure this test gets updated
+    buf[0] = 5;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 1);
+
+    // Should always fail
+    buf[0] = 255;
+    buf[1] = 255;
+    buf[2] = 255;
+    buf[3] = 255;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_instruction_kind(&parser, &kind) == 1);
+}
+
+void test_parse_vote_authorize_enum() {
+    enum VoteAuthorize authorize;
+    uint8_t buf[] = {0, 0, 0, 0};
+    Parser parser = {buf, ARRAY_LEN(buf)};
+    assert(parse_vote_authorize(&parser, &authorize) == 0);
+    assert(authorize == VoteAuthorizeVoter);
+
+    buf[0] = 1;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_authorize(&parser, &authorize) == 0);
+    assert(authorize == VoteAuthorizeWithdrawer);
+
+    // Fail the first unused enum value to be sure this test gets updated
+    buf[0] = 2;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_authorize(&parser, &authorize) == 1);
+
+    // Should always fail
+    buf[0] = 255;
+    buf[1] = 255;
+    buf[2] = 255;
+    buf[3] = 255;
+    parser.buffer = buf;
+    parser.buffer_length = ARRAY_LEN(buf);
+    assert(parse_vote_authorize(&parser, &authorize) == 1);
+}
+
+int main() {
+    test_parse_vote_instruction_kind();
+    test_parse_vote_authorize_enum();
+
+    printf("passed\n");
+    return 0;
+}


### PR DESCRIPTION
#### Problem

Parsers for new enums weren't being tested

#### Changes

Add tests for `VoteInstructionKind` `VoteAuthorize` and `StakeAuthorize` enum parsers