### PR TITLE
Return complete app version

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -77,7 +77,7 @@ void handleApdu(volatile unsigned int *flags, volatile unsigned int *tx) {
                     G_io_apdu_buffer[2] = LEDGER_MAJOR_VERSION;
                     G_io_apdu_buffer[3] = LEDGER_MINOR_VERSION;
                     G_io_apdu_buffer[4] = LEDGER_PATCH_VERSION;
-                    *tx = 4;
+                    *tx = 5;
                     THROW(0x9000);
                     break;
 


### PR DESCRIPTION
`INS_GET_APP_CONFIGURATION(16)` cases are only returning 4 bytes, which chops off the app patch version. Fixup to return complete app version.

We'll want this to update solana-remote-wallet to handle https://github.com/solana-labs/ledger-app-solana/pull/107