### PR TITLE
Enable future support for muliple derivation paths

### DIFF
--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -10,6 +10,7 @@
 
 static uint8_t G_message[MAX_MESSAGE_LENGTH];
 static int G_messageLength;
+static uint8_t G_numDerivationPaths;
 static uint32_t G_derivationPath[BIP32_PATH];
 static int G_derivationPathLength;
 
@@ -115,6 +116,17 @@ void handleSignMessage(
         MEMCLEAR(G_derivationPath);
         MEMCLEAR(G_message);
 	    G_messageLength = 0;
+        G_numDerivationPaths = 0;
+
+        if (!deprecated_host) {
+            G_numDerivationPaths = dataBuffer[0];
+            dataBuffer++;
+            dataLength--;
+            // We only support one derivation path ATM
+            if (G_numDerivationPaths != 1) {
+                THROW(EXCEPTION_OVERFLOW);
+            }
+        }
 
         G_derivationPathLength = read_derivation_path(
             dataBuffer,

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -115,7 +115,7 @@ void handleSignMessage(
     if ((p2 & P2_EXTEND) == 0) {
         MEMCLEAR(G_derivationPath);
         MEMCLEAR(G_message);
-	    G_messageLength = 0;
+        G_messageLength = 0;
         G_numDerivationPaths = 0;
 
         if (!deprecated_host) {

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -105,9 +105,9 @@ void handleSignMessage(
     volatile unsigned int *flags,
     volatile unsigned int *tx
 ) {
-    int data_has_length_prefix = (dataLength & DATA_HAS_LENGTH_PREFIX);
+    int deprecated_host = ((dataLength & DATA_HAS_LENGTH_PREFIX) != 0);
 
-    if (data_has_length_prefix) {
+    if (deprecated_host) {
         dataLength &= ~DATA_HAS_LENGTH_PREFIX;
     }
 
@@ -126,7 +126,7 @@ void handleSignMessage(
     }
 
     int messageLength;
-    if (data_has_length_prefix) {
+    if (deprecated_host) {
         messageLength = U2BE(dataBuffer, 0);
         dataBuffer += 2;
     } else {


### PR DESCRIPTION
#### Problem

Since the app only supports a single signer ATM, the wire format provides no way to specify the number of derivation paths.  This will require an ABI break in the future to enable multiple signers in a single wallet session.  Since we just broke ABI to support Ledger's JS lib, we may as well enable this now

#### Changes

Add a `uint8_t` prefix to the derivation path, specifying the number of derivation paths to expect (MUST be `1` for now)