### PR TITLE
Switch update `node` verbiage to `validator id` to match upstream

### DIFF
--- a/libsol/vote_instruction.h
+++ b/libsol/vote_instruction.h
@@ -9,11 +9,11 @@ enum VoteInstructionKind {
     VoteAuthorize,
     VoteVote,
     VoteWithdraw,
-    VoteUpdateNode,
+    VoteUpdateValidatorId,
 };
 
 typedef struct VoteInitData {
-    const Pubkey* node;
+    const Pubkey* validator_id;
     const Pubkey* vote_authority;
     const Pubkey* withdraw_authority;
     uint64_t commission;
@@ -43,11 +43,11 @@ typedef struct VoteAuthorizeInfo {
     enum VoteAuthorize authorize;
 } VoteAuthorizeInfo;
 
-typedef struct VoteUpdateNodeInfo {
+typedef struct VoteUpdateValidatorIdInfo {
     const Pubkey* account;
     const Pubkey* authority;
-    const Pubkey* node_identity;
-} VoteUpdateNodeInfo;
+    const Pubkey* new_validator_id;
+} VoteUpdateValidatorIdInfo;
 
 typedef struct VoteInfo {
     enum VoteInstructionKind kind;
@@ -55,7 +55,7 @@ typedef struct VoteInfo {
         VoteInitializeInfo initialize;
         VoteWithdrawInfo withdraw;
         VoteAuthorizeInfo authorize;
-        VoteUpdateNodeInfo update_node;
+        VoteUpdateValidatorIdInfo update_validator_id;
     };
 } VoteInfo;
 

--- a/libsol/vote_instruction_test.c
+++ b/libsol/vote_instruction_test.c
@@ -31,7 +31,7 @@ void test_parse_vote_instruction_kind() {
     parser.buffer = buf;
     parser.buffer_length = ARRAY_LEN(buf);
     assert(parse_vote_instruction_kind(&parser, &kind) == 0);
-    assert(kind == VoteUpdateNode);
+    assert(kind == VoteUpdateValidatorId);
 
     // Fail the first unused enum value to be sure this test gets updated
     buf[0] = 5;


### PR DESCRIPTION
#### Problem

App uses old "node" verbiage in reference to updating the validator for a vote account

#### Changes

Update it throughout