### PR TITLE
Add some app settings

### DIFF
--- a/libsol/include/sol/transaction_summary.h
+++ b/libsol/include/sol/transaction_summary.h
@@ -48,6 +48,10 @@ extern char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
 void transaction_summary_reset();
 enum DisplayFlags {
     DisplayFlagNone         = 0,
+    DisplayFlagLongPubkeys  = 1 << 0,
+    DisplayFlagAll          = (
+        DisplayFlagLongPubkeys
+    ),
 };
 int transaction_summary_display_item(size_t item_index, enum DisplayFlags flags);
 int transaction_summary_finalize(

--- a/libsol/include/sol/transaction_summary.h
+++ b/libsol/include/sol/transaction_summary.h
@@ -46,7 +46,10 @@ extern char G_transaction_summary_title[TITLE_SIZE];
 extern char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
 
 void transaction_summary_reset();
-int transaction_summary_display_item(size_t item_index);
+enum DisplayFlags {
+    DisplayFlagNone         = 0,
+};
+int transaction_summary_display_item(size_t item_index, enum DisplayFlags flags);
 int transaction_summary_finalize(
     enum SummaryItemKind* item_kinds,
     size_t* item_kinds_len

--- a/libsol/message_test.c
+++ b/libsol/message_test.c
@@ -136,7 +136,7 @@ static void process_message_body_and_sanity_check(const uint8_t* message, size_t
     assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
     assert(num_kinds == expected_fields);
     for (size_t i = 0; i < num_kinds; i++) {
-        assert(transaction_summary_display_item(i) == 0);
+        assert(transaction_summary_display_item(i, DisplayFlagNone) == 0);
     }
 }
 
@@ -639,7 +639,7 @@ void test_process_message_body_vote_update_node_v1_0_7() {
     char expected[SUMMARY_LENGTH + 2 + SUMMARY_LENGTH + 1];
     print_summary(bs58_expected, expected, sizeof(expected), SUMMARY_LENGTH, SUMMARY_LENGTH);
 
-    transaction_summary_display_item(1); // node id
+    transaction_summary_display_item(1, DisplayFlagNone); // node id
     assert_string_equal(G_transaction_summary_text, expected);
 }
 
@@ -672,7 +672,7 @@ void test_process_message_body_vote_update_node_v1_0_8() {
     char expected[SUMMARY_LENGTH + 2 + SUMMARY_LENGTH + 1];
     print_summary(bs58_expected, expected, sizeof(expected), SUMMARY_LENGTH, SUMMARY_LENGTH);
 
-    transaction_summary_display_item(1); // node id
+    transaction_summary_display_item(1, DisplayFlagNone); // node id
     assert_string_equal(G_transaction_summary_text, expected);
 }
 

--- a/libsol/system_instruction_test.c
+++ b/libsol/system_instruction_test.c
@@ -273,11 +273,11 @@ void test_process_system_transfer() {
     assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
     assert(num_kinds == 4);
 
-    transaction_summary_display_item(0);
+    transaction_summary_display_item(0, DisplayFlagNone);
     assert_string_equal(G_transaction_summary_text, "0.000000042 SOL");
 
     // Fee-payer is sender
-    transaction_summary_display_item(3);
+    transaction_summary_display_item(3, DisplayFlagNone);
     assert_string_equal(G_transaction_summary_text, "sender");
 }
 

--- a/libsol/transaction_summary.c
+++ b/libsol/transaction_summary.c
@@ -160,7 +160,8 @@ int transaction_summary_set_fee_payer_string(const char* string) {
 }
 
 static int transaction_summary_update_display_for_item(
-    const SummaryItem* item
+    const SummaryItem* item,
+    enum DisplayFlags flags
 ) {
     switch (item->kind) {
         case SummaryItemNone:
@@ -236,7 +237,7 @@ static int transaction_summary_update_display_for_item(
     return 0;
 }
 
-int transaction_summary_display_item(size_t item_index) {
+int transaction_summary_display_item(size_t item_index, enum DisplayFlags flags) {
     struct TransactionSummary* summary = &G_transaction_summary;
     SummaryItem* item = NULL;
     SummaryItem* maybe_item = &summary->primary;
@@ -284,7 +285,7 @@ int transaction_summary_display_item(size_t item_index) {
         return 1;
     }
 
-    return transaction_summary_update_display_for_item(item);
+    return transaction_summary_update_display_for_item(item, flags);
 }
 
 #define SET_IF_USED(item, item_kinds, index)    \

--- a/libsol/transaction_summary.c
+++ b/libsol/transaction_summary.c
@@ -199,14 +199,23 @@ static int transaction_summary_update_display_for_item(
                 tmp_buf,
                 sizeof(tmp_buf)
             ));
-            BAIL_IF(
-                print_summary(
-                    tmp_buf,
-                    G_transaction_summary_text,
-                    BASE58_PUBKEY_SHORT,
-                    SUMMARY_LENGTH,
-                    SUMMARY_LENGTH
-            ));
+            if (flags & DisplayFlagLongPubkeys) {
+                BAIL_IF(
+                    print_string(
+                        tmp_buf,
+                        G_transaction_summary_text,
+                        TEXT_BUFFER_LENGTH
+                ));
+            } else {
+                BAIL_IF(
+                    print_summary(
+                        tmp_buf,
+                        G_transaction_summary_text,
+                        BASE58_PUBKEY_SHORT,
+                        SUMMARY_LENGTH,
+                        SUMMARY_LENGTH
+                ));
+            }
             break;
         }
         case SummaryItemHash:

--- a/libsol/transaction_summary_test.c
+++ b/libsol/transaction_summary_test.c
@@ -148,30 +148,30 @@ void test_transaction_summary_update_display_for_item() {
     SummaryItem item;
 
     item.kind = SummaryItemNone;
-    assert(transaction_summary_update_display_for_item(&item) == 1);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 1);
 
     summary_item_set_amount(&item, "amount", 42);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("amount", "0.000000042 SOL");
 
     summary_item_set_i64(&item, "i64", -42);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("i64", "-42");
 
     summary_item_set_u64(&item, "u64", 4242);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("u64", "4242");
 
     Pubkey pubkey;
     memset(&pubkey, 0, sizeof(Pubkey));
     summary_item_set_pubkey(&item, "pubkey", &pubkey);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("pubkey", "1111111..1111111");
 
     Hash hash;
     memset(&hash, 0, sizeof(Hash));
     summary_item_set_hash(&item, "hash", &hash);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display(
         "hash",
         "11111111111111111111111111111111"
@@ -180,12 +180,12 @@ void test_transaction_summary_update_display_for_item() {
     uint8_t string_data[] = { 0x74, 0x65, 0x73, 0x74 };
     SizedString sized_string = { sizeof(string_data), (char*)string_data };
     summary_item_set_sized_string(&item, "sizedString", &sized_string);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("sizedString", "test");
 
     const char* string = "value";
     summary_item_set_string(&item, "string", string);
-    assert(transaction_summary_update_display_for_item(&item) == 0);
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("string", "value");
 }
 
@@ -194,18 +194,28 @@ void test_transaction_summary_update_display_for_item() {
         SummaryItem* si;                                                \
         assert((si = transaction_summary_ ## item ## _item()) != NULL); \
         summary_item_set_u64(si, #item, 42);                            \
-        assert(transaction_summary_display_item(item_index) == 0);      \
+        assert(                                                         \
+            transaction_summary_display_item(                           \
+                item_index,                                             \
+                DisplayFlagNone                                         \
+            ) == 0                                                      \
+        );                                                              \
         assert_transaction_summary_display(#item, "42");                \
     } while (0)
 
-#define display_item_test_helper_general_item(general_index)                \
-    do {                                                                    \
-        SummaryItem* si;                                                    \
-        const char* title = "general_" #general_index;                      \
-        assert((si = transaction_summary_general_item()) != NULL);          \
-        summary_item_set_u64(si, title, 42);                                \
-        assert(transaction_summary_display_item(general_index + 1) == 0);   \
-        assert_transaction_summary_display(title, "42");                    \
+#define display_item_test_helper_general_item(general_index)        \
+    do {                                                            \
+        SummaryItem* si;                                            \
+        const char* title = "general_" #general_index;              \
+        assert((si = transaction_summary_general_item()) != NULL);  \
+        summary_item_set_u64(si, title, 42);                        \
+        assert(                                                     \
+            transaction_summary_display_item(                       \
+                general_index + 1,                                  \
+                DisplayFlagNone                                     \
+            ) == 0                                                  \
+        );                                                          \
+        assert_transaction_summary_display(title, "42");            \
     } while (0)
 
 void test_transaction_summary_display_item() {
@@ -344,15 +354,15 @@ void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug() {
     assert(transaction_summary_finalize(kinds, &num_kinds) == 0);
     assert(num_kinds == 3);
 
-    assert(transaction_summary_display_item(0) == 0);
+    assert(transaction_summary_display_item(0, DisplayFlagNone) == 0);
     assert_transaction_summary_display(primary_title, primary_text);
-    assert(transaction_summary_display_item(1) == 0);
+    assert(transaction_summary_display_item(1, DisplayFlagNone) == 0);
     assert_transaction_summary_display(message_hash_title, message_hash_text);
-    assert(transaction_summary_display_item(2) == 0);
+    assert(transaction_summary_display_item(2, DisplayFlagNone) == 0);
     assert_transaction_summary_display(fee_payer_title, fee_payer_text);
-    assert(transaction_summary_display_item(1) == 0);
+    assert(transaction_summary_display_item(1, DisplayFlagNone) == 0);
     assert_transaction_summary_display(message_hash_title, message_hash_text);
-    assert(transaction_summary_display_item(0) == 0);
+    assert(transaction_summary_display_item(0, DisplayFlagNone) == 0);
     assert_transaction_summary_display(primary_title, primary_text);
 }
 

--- a/libsol/transaction_summary_test.c
+++ b/libsol/transaction_summary_test.c
@@ -167,6 +167,8 @@ void test_transaction_summary_update_display_for_item() {
     summary_item_set_pubkey(&item, "pubkey", &pubkey);
     assert(transaction_summary_update_display_for_item(&item, DisplayFlagNone) == 0);
     assert_transaction_summary_display("pubkey", "1111111..1111111");
+    assert(transaction_summary_update_display_for_item(&item, DisplayFlagLongPubkeys) == 0);
+    assert_transaction_summary_display("pubkey", "11111111111111111111111111111111");
 
     Hash hash;
     memset(&hash, 0, sizeof(Hash));

--- a/src/globals.h
+++ b/src/globals.h
@@ -28,8 +28,17 @@ extern ux_state_t ux;
 extern unsigned int ux_step;
 extern unsigned int ux_step_count;
 
+enum BlindSign {
+    BlindSignDisabled = 0,
+    BlindSignEnabled = 1,
+};
+
+typedef struct AppSettings {
+    uint8_t allow_blind_sign;
+} AppSettings;
+
 typedef struct internalStorage_t {
-    unsigned char dummy_setting_1;
+    AppSettings settings;
     unsigned char dummy_setting_2;
     uint8_t initialized;
 } internalStorage_t;

--- a/src/globals.h
+++ b/src/globals.h
@@ -33,13 +33,18 @@ enum BlindSign {
     BlindSignEnabled = 1,
 };
 
+enum PubkeyDisplay {
+    PubkeyDisplayLong = 0,
+    PubkeyDisplayShort = 1,
+};
+
 typedef struct AppSettings {
     uint8_t allow_blind_sign;
+    uint8_t pubkey_display;
 } AppSettings;
 
 typedef struct internalStorage_t {
     AppSettings settings;
-    unsigned char dummy_setting_2;
     uint8_t initialized;
 } internalStorage_t;
 

--- a/src/main.c
+++ b/src/main.c
@@ -73,7 +73,7 @@ void handleApdu(volatile unsigned int *flags, volatile unsigned int *tx) {
                 case INS_GET_APP_CONFIGURATION:
                 case INS_GET_APP_CONFIGURATION16:
                     G_io_apdu_buffer[0] = N_storage.settings.allow_blind_sign;
-                    G_io_apdu_buffer[1] = (N_storage.dummy_setting_2 ? 0x01 : 0x00);
+                    G_io_apdu_buffer[1] = N_storage.settings.pubkey_display;
                     G_io_apdu_buffer[2] = LEDGER_MAJOR_VERSION;
                     G_io_apdu_buffer[3] = LEDGER_MINOR_VERSION;
                     G_io_apdu_buffer[4] = LEDGER_PATCH_VERSION;
@@ -313,7 +313,7 @@ void nv_app_state_init(){
     if (N_storage.initialized != 0x01) {
         internalStorage_t storage;
         storage.settings.allow_blind_sign = BlindSignDisabled;
-        storage.dummy_setting_2 = 0x00;
+        storage.settings.pubkey_display = PubkeyDisplayLong;
         storage.initialized = 0x01;
         nvm_write(
             (internalStorage_t*)&N_storage,
@@ -321,7 +321,6 @@ void nv_app_state_init(){
             sizeof(internalStorage_t)
         );
     }
-    dummy_setting_2 = N_storage.dummy_setting_2;
 }
 
 __attribute__((section(".boot"))) int main(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -72,7 +72,7 @@ void handleApdu(volatile unsigned int *flags, volatile unsigned int *tx) {
             switch (G_io_apdu_buffer[OFFSET_INS]) {
                 case INS_GET_APP_CONFIGURATION:
                 case INS_GET_APP_CONFIGURATION16:
-                    G_io_apdu_buffer[0] = (N_storage.dummy_setting_1 ? 0x01 : 0x00);
+                    G_io_apdu_buffer[0] = N_storage.settings.allow_blind_sign;
                     G_io_apdu_buffer[1] = (N_storage.dummy_setting_2 ? 0x01 : 0x00);
                     G_io_apdu_buffer[2] = LEDGER_MAJOR_VERSION;
                     G_io_apdu_buffer[3] = LEDGER_MINOR_VERSION;
@@ -312,7 +312,7 @@ void app_exit(void) {
 void nv_app_state_init(){
     if (N_storage.initialized != 0x01) {
         internalStorage_t storage;
-        storage.dummy_setting_1 = 0x00;
+        storage.settings.allow_blind_sign = BlindSignDisabled;
         storage.dummy_setting_2 = 0x00;
         storage.initialized = 0x01;
         nvm_write(
@@ -321,7 +321,6 @@ void nv_app_state_init(){
             sizeof(internalStorage_t)
         );
     }
-    dummy_setting_1 = N_storage.dummy_setting_1;
     dummy_setting_2 = N_storage.dummy_setting_2;
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -1,11 +1,9 @@
 #include "menu.h"
 #include "os.h"
 
-volatile uint8_t dummy_setting_2;
-
 void display_settings(void);
 void switch_allow_blind_sign_data(void);
-void switch_dummy_setting_2_data(void);
+void switch_pubkey_display_data(void);
 
 //////////////////////////////////////////////////////////////////////
 const char* settings_submenu_getter(unsigned int idx);
@@ -53,33 +51,40 @@ void allow_blind_sign_data_selector(unsigned int idx) {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////
-// Display contract data submenu:
+// Pubkey display submenu
 
-void dummy_setting_2_data_change(unsigned int enabled) {
-    nvm_write((void *)&N_storage.dummy_setting_2, &enabled, 1);
+void pubkey_display_data_change(enum PubkeyDisplay pubkey_display) {
+    uint8_t value;
+    switch (pubkey_display) {
+        case PubkeyDisplayLong:
+        case PubkeyDisplayShort:
+            value = (uint8_t) pubkey_display;
+            nvm_write((void *)&N_storage.settings.pubkey_display, &value, sizeof(value));
+            break;
+    }
     ui_idle();
 }
 
-const char* const dummy_setting_2_data_getter_values[] = {
-  "No",
-  "Yes",
+const char* const pubkey_display_data_getter_values[] = {
+  "Long",
+  "Short",
   "Back"
 };
 
-const char* dummy_setting_2_data_getter(unsigned int idx) {
-  if (idx < ARRAYLEN(dummy_setting_2_data_getter_values)) {
-    return dummy_setting_2_data_getter_values[idx];
+static const char* pubkey_display_data_getter(unsigned int idx) {
+  if (idx < ARRAYLEN(pubkey_display_data_getter_values)) {
+    return pubkey_display_data_getter_values[idx];
   }
   return NULL;
 }
 
-void dummy_setting_2_data_selector(unsigned int idx) {
+static void pubkey_display_data_selector(unsigned int idx) {
   switch(idx) {
     case 0:
-      dummy_setting_2_data_change(0);
+      pubkey_display_data_change(PubkeyDisplayLong);
       break;
     case 1:
-      dummy_setting_2_data_change(1);
+      pubkey_display_data_change(PubkeyDisplayShort);
       break;
     default:
       ux_menulist_init(0, settings_submenu_getter, settings_submenu_selector);
@@ -91,7 +96,7 @@ void dummy_setting_2_data_selector(unsigned int idx) {
 
 const char* const settings_submenu_getter_values[] = {
   "Allow blind sign",
-  "Dummy setting 2",
+  "Pubkey display",
   "Back",
 };
 
@@ -108,7 +113,7 @@ void settings_submenu_selector(unsigned int idx) {
       ux_menulist_init_select(0, allow_blind_sign_data_getter, allow_blind_sign_data_selector, N_storage.settings.allow_blind_sign);
       break;
     case 1:
-      ux_menulist_init_select(0, dummy_setting_2_data_getter, dummy_setting_2_data_selector, N_storage.dummy_setting_2);
+      ux_menulist_init_select(0, pubkey_display_data_getter, pubkey_display_data_selector, N_storage.settings.pubkey_display);
       break;
     default:
       ui_idle();

--- a/src/menu.h
+++ b/src/menu.h
@@ -4,7 +4,6 @@
 #ifndef _MENU_H_
 #define _MENU_H_
 
-extern volatile uint8_t dummy_setting_1;
 extern volatile uint8_t dummy_setting_2;
 
 void ui_idle(void);

--- a/src/menu.h
+++ b/src/menu.h
@@ -4,8 +4,6 @@
 #ifndef _MENU_H_
 #define _MENU_H_
 
-extern volatile uint8_t dummy_setting_2;
-
 void ui_idle(void);
 
 #endif

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -2,6 +2,7 @@
 #include "os.h"
 #include "ux.h"
 #include "cx.h"
+#include "menu.h"
 #include "utils.h"
 #include "sol/parser.h"
 #include "sol/printer.h"
@@ -173,18 +174,22 @@ void handleSignMessage(
 
     transaction_summary_reset();
     if (process_message_body(parser.buffer, parser.buffer_length, &header)) {
-        SummaryItem* item = transaction_summary_primary_item();
-        summary_item_set_string(item, "Unrecognized", "format");
+        if (N_storage.settings.allow_blind_sign == BlindSignEnabled) {
+            SummaryItem* item = transaction_summary_primary_item();
+            summary_item_set_string(item, "Unrecognized", "format");
 
-        cx_hash_sha256(
-            dataBuffer,
-            dataLength,
-            (uint8_t*) &UnrecognizedMessageHash,
-            HASH_LENGTH
-        );
+            cx_hash_sha256(
+                dataBuffer,
+                dataLength,
+                (uint8_t*) &UnrecognizedMessageHash,
+                HASH_LENGTH
+            );
 
-        item = transaction_summary_general_item();
-        summary_item_set_hash(item, "Message Hash", &UnrecognizedMessageHash);
+            item = transaction_summary_general_item();
+            summary_item_set_hash(item, "Message Hash", &UnrecognizedMessageHash);
+        } else {
+            THROW(NOT_SUPPORTED);
+        }
     }
 
     // Set fee-payer if it hasn't already been resolved by

--- a/src/signMessage.c
+++ b/src/signMessage.c
@@ -79,7 +79,11 @@ UX_STEP_NOCB_INIT(
     paging,
     {
         size_t step_index = G_ux.flow_stack[stack_slot].index;
-        if (transaction_summary_display_item(step_index)) {
+        enum DisplayFlags flags = DisplayFlagNone;
+        if (N_storage.settings.pubkey_display == PubkeyDisplayLong) {
+            flags |=  DisplayFlagLongPubkeys;
+        }
+        if (transaction_summary_display_item(step_index, flags)) {
             THROW(0x6f01);
         }
     },


### PR DESCRIPTION
#### Problem

Some app default behaviors are risky for unsophisticated users, but eliminating them would limit use cases.

#### Changes

Re-enable settings
Add an "Allow blind signing" setting and fail signing unparsable transaction if it is disabled (default)
Introduce a flags parameter for displaying `SummaryItem`s
Add a `SummaryItem` display flag for to print full length `Pubkey`s
Add a "Public display" setting to let the user choose between long (default) and short `Pubkey` display