### PR TITLE
Show short addresses by default

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -313,7 +313,7 @@ void nv_app_state_init(){
     if (N_storage.initialized != 0x01) {
         internalStorage_t storage;
         storage.settings.allow_blind_sign = BlindSignDisabled;
-        storage.settings.pubkey_display = PubkeyDisplayLong;
+        storage.settings.pubkey_display = PubkeyDisplayShort;
         storage.initialized = 0x01;
         nvm_write(
             (internalStorage_t*)&N_storage,


### PR DESCRIPTION
#### Problem

Long pubkeys by default encourages the user to blindly click through to approve.

#### Proposed changes

Short pubkeys by default