### PR TITLE
Fix `stake-set-lockup` authority display

### DIFF
--- a/libsol/stake_instruction.c
+++ b/libsol/stake_instruction.c
@@ -214,8 +214,6 @@ static int parse_stake_set_lockup_instruction(
     size_t pubkeys_index = instruction->accounts[accounts_index++];
     info->account = &header->pubkeys[pubkeys_index];
 
-    accounts_index++; // Skip clock sysvar
-
     pubkeys_index = instruction->accounts[accounts_index++];
     info->custodian = &header->pubkeys[pubkeys_index];
 


### PR DESCRIPTION
#### Problem

A parsed TX from `solana set-stake-lockup` displays garbage instead of the custodian pubkey

#### Changes

Don't skip the `Clock` sysvar pubkey, this instruction has no such parameter

@garious mind confirming this on device?