### PR TITLE
Instruction accounts iterator

### DIFF
--- a/libsol/instruction.c
+++ b/libsol/instruction.c
@@ -63,3 +63,29 @@ bool instruction_infos_match_briefs(
     }
     return (i == len);
 }
+
+void instruction_accounts_iterator_init(
+    InstructionAccountsIterator* it,
+    const MessageHeader* header,
+    const Instruction* instruction
+) {
+    it->message_header_pubkeys = header->pubkeys;
+    it->instruction_accounts_length = instruction->accounts_length;
+    it->instruction_accounts = instruction->accounts;
+    it->current_instruction_account = 0;
+}
+
+int instruction_accounts_iterator_next(
+    InstructionAccountsIterator* it,
+    const Pubkey** next_account
+) {
+    if (it->current_instruction_account < it->instruction_accounts_length) {
+        size_t pubkeys_index =
+            it->instruction_accounts[it->current_instruction_account++];
+        if (next_account) {
+            *next_account = &it->message_header_pubkeys[pubkeys_index];
+        }
+        return 0;
+    }
+    return 1;
+}

--- a/libsol/instruction.h
+++ b/libsol/instruction.h
@@ -54,3 +54,22 @@ bool instruction_infos_match_briefs(
     const InstructionBrief* briefs,
     size_t len
 );
+
+
+typedef struct InstructionAccountsIterator {
+    const Pubkey* message_header_pubkeys;
+    uint8_t instruction_accounts_length;
+    const uint8_t* instruction_accounts;
+    size_t current_instruction_account;
+} InstructionAccountsIterator;
+
+void instruction_accounts_iterator_init(
+    InstructionAccountsIterator* it,
+    const MessageHeader* header,
+    const Instruction* instruction
+);
+
+int instruction_accounts_iterator_next(
+    InstructionAccountsIterator* it,
+    const Pubkey** next_account
+);

--- a/libsol/vote_instruction.c
+++ b/libsol/vote_instruction.c
@@ -49,7 +49,9 @@ static int parse_vote_initialize_instruction(
     instruction_accounts_iterator_init(&it, header, instruction);
 
     BAIL_IF(instruction_accounts_iterator_next(&it, &info->account));
+    // Skip rent sysvat
     BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
+    // Skip clock sysvar
     BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
 
     BAIL_IF(parse_pubkey(parser, &info->vote_init.validator_id));

--- a/libsol/vote_instruction.c
+++ b/libsol/vote_instruction.c
@@ -1,4 +1,5 @@
 #include "common_byte_strings.h"
+#include "instruction.h"
 #include "sol/transaction_summary.h"
 #include "util.h"
 #include "vote_instruction.h"
@@ -44,13 +45,12 @@ static int parse_vote_initialize_instruction(
     const MessageHeader* header,
     VoteInitializeInfo* info
 ) {
-    BAIL_IF(instruction->accounts_length < 3);
-    size_t accounts_index = 0;
-    size_t pubkeys_index = instruction->accounts[accounts_index++];
-    info->account = &header->pubkeys[pubkeys_index];
+    InstructionAccountsIterator it;
+    instruction_accounts_iterator_init(&it, header, instruction);
 
-    accounts_index++; // Skip rent sysvar
-    accounts_index++; // Skip clock sysvar
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->account));
+    BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
+    BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
 
     BAIL_IF(parse_pubkey(parser, &info->vote_init.validator_id));
     BAIL_IF(parse_pubkey(parser, &info->vote_init.vote_authority));
@@ -68,16 +68,12 @@ static int parse_vote_withdraw_instruction(
     const MessageHeader* header,
     VoteWithdrawInfo* info
 ) {
-    BAIL_IF(instruction->accounts_length < 3);
-    size_t accounts_index = 0;
-    size_t pubkeys_index = instruction->accounts[accounts_index++];
-    info->account = &header->pubkeys[pubkeys_index];
+    InstructionAccountsIterator it;
+    instruction_accounts_iterator_init(&it, header, instruction);
 
-    pubkeys_index = instruction->accounts[accounts_index++];
-    info->to = &header->pubkeys[pubkeys_index];
-
-    pubkeys_index = instruction->accounts[accounts_index++];
-    info->authority = &header->pubkeys[pubkeys_index];
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->account));
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->to));
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->authority));
 
     BAIL_IF(parse_u64(parser, &info->lamports));
 
@@ -90,15 +86,13 @@ static int parse_vote_authorize_instruction(
     const MessageHeader* header,
     VoteAuthorizeInfo* info
 ) {
-    BAIL_IF(instruction->accounts_length < 3);
-    size_t accounts_index = 0;
-    size_t pubkeys_index = instruction->accounts[accounts_index++];
-    info->account = &header->pubkeys[pubkeys_index];
+    InstructionAccountsIterator it;
+    instruction_accounts_iterator_init(&it, header, instruction);
 
-    accounts_index++; // Skip clock sysvar
-
-    pubkeys_index = instruction->accounts[accounts_index++];
-    info->authority = &header->pubkeys[pubkeys_index];
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->account));
+    // Skip clock sysvar
+    BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->authority));
 
     BAIL_IF(parse_pubkey(parser, &info->new_authority));
     BAIL_IF(parse_vote_authorize(parser, &info->authorize));
@@ -112,29 +106,27 @@ static int parse_vote_update_validator_id_instruction(
     const MessageHeader* header,
     VoteUpdateValidatorIdInfo* info
 ) {
-    BAIL_IF(instruction->accounts_length < 3);
-    size_t accounts_index = 0;
-    size_t pubkeys_index = instruction->accounts[accounts_index++];
-    info->account = &header->pubkeys[pubkeys_index];
+    InstructionAccountsIterator it;
+    instruction_accounts_iterator_init(&it, header, instruction);
 
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->account));
     if (instruction->data_length == sizeof(uint32_t)) {
         // 1.0.8+, 1.1.3+ format
         // https://github.com/solana-labs/solana/pull/8947
-        pubkeys_index = instruction->accounts[accounts_index++];
-        info->new_validator_id = &header->pubkeys[pubkeys_index];
+        BAIL_IF(instruction_accounts_iterator_next(&it, &info->new_validator_id))
     } else if (
         instruction->data_length == (sizeof(uint32_t) + sizeof(Pubkey))
     ) {
         // Before 1.0.8 and 1.1.3, the validaotr identity was passed
         // as an instruction arg
         BAIL_IF(parse_pubkey(parser, &info->new_validator_id));
-        accounts_index++; // Skip clock sysvar
+        // Skip clock sysvar
+        BAIL_IF(instruction_accounts_iterator_next(&it, NULL));
     } else {
         return 1;
     }
 
-    pubkeys_index = instruction->accounts[accounts_index++];
-    info->authority = &header->pubkeys[pubkeys_index];
+    BAIL_IF(instruction_accounts_iterator_next(&it, &info->authority));
 
     return 0;
 }


### PR DESCRIPTION
#### Problem

In-place recall of an instruction's account references is error-prone and dangerous, giving opportunity to issues like #119

#### Changes

Add an `InstructionAccountsIterator` type and hide all of the arithmetic and error checking behind it
Replace all in-place instruction account key calculations

@garious mind giving this one an on device check too?